### PR TITLE
WTK-26 Rethrow and catch when error saving line

### DIFF
--- a/src/actions/flexibleLines.ts
+++ b/src/actions/flexibleLines.ts
@@ -154,6 +154,7 @@ export const saveFlexibleLine = (flexibleLine: FlexibleLine) => async (
       )
     );
     sentryCaptureException(e);
+    throw e;
   }
 };
 

--- a/src/i18n/translations/en.ts
+++ b/src/i18n/translations/en.ts
@@ -143,7 +143,7 @@ export const messages: MessagesKey = {
   uttuErrorCONSTRAINT_VIOLATION_SERVICE_JOURNEY_UNIQUE_NAME:
     'Service journey must have a unique name',
   uttuErrorCONSTRAINT_VIOLATION_LINE_UNIQUE_NAME:
-    'Flexible line must have a unique name',
+    'Line must have a unique name',
   uttuErrorCONSTRAINT_VIOLATION_JOURNEY_PATTERN_UNIQUE_NAME:
     'The journey pattern must have a unique name',
   uttuErrorENTITY_IS_REFERENCED:

--- a/src/scenes/Lines/scenes/Editor/index.tsx
+++ b/src/scenes/Lines/scenes/Editor/index.tsx
@@ -139,16 +139,11 @@ const EditorFrame = (props: RouteComponentProps<MatchParams>) => {
     if (valid) {
       setSaving(true);
       dispatch(saveFlexibleLine(line))
-        .then(() => {
-          dispatch(setSavedChanges(true));
-          if (!isEdit) {
-            goToLines();
-          }
-        })
-        .catch(() => {
-          // noop just catching to avoid unhandled rejection
-          // error message is handled upstream
-        })
+        .then(() => dispatch(setSavedChanges(true)))
+        .then(() => !isEdit && goToLines())
+        // noop just catching to avoid unhandled rejection
+        // error message is handled upstream
+        .catch(() => {})
         .finally(() => setSaving(false));
       setNextClicked(false);
     }

--- a/src/scenes/Lines/scenes/Editor/index.tsx
+++ b/src/scenes/Lines/scenes/Editor/index.tsx
@@ -139,9 +139,17 @@ const EditorFrame = (props: RouteComponentProps<MatchParams>) => {
     if (valid) {
       setSaving(true);
       dispatch(saveFlexibleLine(line))
-        .then(() => !isEdit && goToLines())
+        .then(() => {
+          dispatch(setSavedChanges(true));
+          if (!isEdit) {
+            goToLines();
+          }
+        })
+        .catch(() => {
+          // noop just catching to avoid unhandled rejection
+          // error message is handled upstream
+        })
         .finally(() => setSaving(false));
-      dispatch(setSavedChanges(true));
       setNextClicked(false);
     }
   };


### PR DESCRIPTION
Prevent navigation back to /lines and the loss of unsaved data. Simple
solution.