### PR TITLE
make bootstrap.json url base path aware

### DIFF
--- a/src/config/fetchConfig.ts
+++ b/src/config/fetchConfig.ts
@@ -12,11 +12,11 @@ export const fetchConfig = async (): Promise<Config> => {
   if (import.meta.env.VITE_REACT_APP_UTTU_API_URL) {
     overrides.uttuApiUrl = import.meta.env.VITE_REACT_APP_UTTU_API_URL;
   }
-  let input = '/bootstrap.json';
+  let bootstrapUrl = '/bootstrap.json';
   if (import.meta.env.BASE_URL) {
-    input = import.meta.env.BASE_URL + input;
+    bootstrapUrl = import.meta.env.BASE_URL + bootstrapUrl;
   }
-  const response = await fetch(input);
+  const response = await fetch(bootstrapUrl);
   const config: Config = await response.json();
 
   return Object.assign({}, defaultConfig, config, overrides);

--- a/src/config/fetchConfig.ts
+++ b/src/config/fetchConfig.ts
@@ -12,8 +12,11 @@ export const fetchConfig = async (): Promise<Config> => {
   if (import.meta.env.VITE_REACT_APP_UTTU_API_URL) {
     overrides.uttuApiUrl = import.meta.env.VITE_REACT_APP_UTTU_API_URL;
   }
-
-  const response = await fetch('/bootstrap.json');
+  let input = '/bootstrap.json';
+  if (import.meta.env.BASE_URL) {
+    input = import.meta.env.BASE_URL + input;
+  }
+  const response = await fetch(input);
   const config: Config = await response.json();
 
   return Object.assign({}, defaultConfig, config, overrides);


### PR DESCRIPTION
We run enki under base path `/ui` because of how our load balancer is cofigured, so the bootstrap.json file fetching needs to be aware of that.