### PR TITLE
Fix conditional for bootstrapUrl

### DIFF
--- a/src/config/fetchConfig.ts
+++ b/src/config/fetchConfig.ts
@@ -12,11 +12,7 @@ export const fetchConfig = async (): Promise<Config> => {
   if (import.meta.env.VITE_REACT_APP_UTTU_API_URL) {
     overrides.uttuApiUrl = import.meta.env.VITE_REACT_APP_UTTU_API_URL;
   }
-  let bootstrapUrl = '/bootstrap.json';
-  if (import.meta.env.BASE_URL) {
-    bootstrapUrl = import.meta.env.BASE_URL + bootstrapUrl;
-  }
-  const response = await fetch(bootstrapUrl);
+  const response = await fetch(`${import.meta.env.BASE_URL}bootstrap.json`);
   const config: Config = await response.json();
 
   return Object.assign({}, defaultConfig, config, overrides);


### PR DESCRIPTION
Default value of `import.meta.env.BASE_URL` comes from default config param `base`: `/`. This resulted in trying to fetch bootstrap from `//bootstrap.json`, which browsers interpret as "use same protocol as origin" i.e. `https://bootstrap.json`.

This PR changes the logic so that it always uses BASE_URL - keeping in mind that the BASE_URL should include a trailing slash.