### PR TITLE
Initialize empty stop point in flexible line journey pattern

### DIFF
--- a/src/components/StopPointsEditor/FlexibleAreasOnly/FlexibleAreasOnlyStopPointsEditor.tsx
+++ b/src/components/StopPointsEditor/FlexibleAreasOnly/FlexibleAreasOnlyStopPointsEditor.tsx
@@ -1,6 +1,6 @@
 import { Heading3, Paragraph } from '@entur/typography';
 import StopPoint from 'model/StopPoint';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useIntl } from 'react-intl';
 import { StopPointsEditorProps } from '..';
 import { FlexibleAreasOnlyStopPointEditor } from './FlexibleAreasOnlyStopPointEditor';
@@ -9,8 +9,15 @@ export const FlexibleAreasOnlyStopPointsEditor = ({
   pointsInSequence,
   spoilPristine,
   onPointsInSequenceChange,
+  initStopPoints,
 }: StopPointsEditorProps) => {
   const { formatMessage } = useIntl();
+
+  useEffect(() => {
+    if (pointsInSequence?.length === 0) {
+      initStopPoints();
+    }
+  }, []);
 
   const onStopPointUpdate = useCallback(
     (updatedStopPoint: StopPoint) => {
@@ -40,11 +47,13 @@ export const FlexibleAreasOnlyStopPointsEditor = ({
         {formatMessage({ id: 'stopPointsInfoFlexibleAreaOnly' })}
       </Paragraph>
       <div className="stop-point-editor">
-        <FlexibleAreasOnlyStopPointEditor
-          stopPoint={pointsInSequence[0]}
-          spoilPristine={spoilPristine}
-          onChange={onStopPointUpdate}
-        />
+        {pointsInSequence[0] && (
+          <FlexibleAreasOnlyStopPointEditor
+            stopPoint={pointsInSequence[0]}
+            spoilPristine={spoilPristine}
+            onChange={onStopPointUpdate}
+          />
+        )}
       </div>
     </section>
   );


### PR DESCRIPTION
A bug was introduced as part of: https://github.com/entur/enki/pull/1578 
The bug is: an error occurs at the time of flexible line creation due to a missing empty stop point
<img width="575" alt="Screenshot 2024-10-22 at 17 23 22" src="https://github.com/user-attachments/assets/3d3ad5a4-c58e-4bdd-adc3-01dd38c42a97">

