### PR TITLE
Initialize journey pattern properly

### DIFF
--- a/src/components/GeneralLineEditor/index.tsx
+++ b/src/components/GeneralLineEditor/index.tsx
@@ -70,7 +70,7 @@ export default <T extends Line>({
           serviceJourneys: journeyPattern.serviceJourneys.map(
             (serviceJourney: ServiceJourney) => ({
               ...serviceJourney,
-              passingTimes: [{}, {}],
+              passingTimes: [],
             }),
           ),
           pointsInSequence: [],

--- a/src/components/JourneyPatternEditor/index.tsx
+++ b/src/components/JourneyPatternEditor/index.tsx
@@ -13,6 +13,7 @@ import General from './General';
 import './styles.scss';
 import { useConfig } from '../../config/ConfigContext';
 import { VEHICLE_MODE } from '../../model/enums';
+import ServiceJourney from '../../model/ServiceJourney';
 
 type Props = {
   journeyPattern: JourneyPattern;
@@ -86,11 +87,16 @@ const JourneyPatternEditor = ({
     [journeyPattern, onSave, serviceJourneys],
   );
 
-  const initStopPoints = useCallback(() => {
+  const initDefaultJourneyPattern = useCallback(() => {
     onSave({
       ...journeyPattern,
       pointsInSequence: [{}, {}],
-      serviceJourneys,
+      serviceJourneys: journeyPattern.serviceJourneys.map(
+        (serviceJourney: ServiceJourney) => ({
+          ...serviceJourney,
+          passingTimes: [{}, {}],
+        }),
+      ),
     });
   }, [journeyPattern, onSave, serviceJourneys]);
 
@@ -139,7 +145,7 @@ const JourneyPatternEditor = ({
           addStopPoint={addStopPoint}
           onPointsInSequenceChange={onPointsInSequenceChange}
           transportMode={transportMode}
-          initStopPoints={initStopPoints}
+          initDefaultJourneyPattern={initDefaultJourneyPattern}
         />
       </div>
       {onDelete && (

--- a/src/components/StopPointsEditor/FlexibleAreasOnly/FlexibleAreasOnlyStopPointsEditor.tsx
+++ b/src/components/StopPointsEditor/FlexibleAreasOnly/FlexibleAreasOnlyStopPointsEditor.tsx
@@ -9,13 +9,13 @@ export const FlexibleAreasOnlyStopPointsEditor = ({
   pointsInSequence,
   spoilPristine,
   onPointsInSequenceChange,
-  initStopPoints,
+  initDefaultJourneyPattern,
 }: StopPointsEditorProps) => {
   const { formatMessage } = useIntl();
 
   useEffect(() => {
     if (pointsInSequence?.length === 0) {
-      initStopPoints();
+      initDefaultJourneyPattern();
     }
   }, []);
 

--- a/src/components/StopPointsEditor/Generic/GenericStopPointsEditor.tsx
+++ b/src/components/StopPointsEditor/Generic/GenericStopPointsEditor.tsx
@@ -20,7 +20,7 @@ export const GenericStopPointsEditor = ({
   addStopPoint,
   flexibleLineType,
   transportMode,
-  initStopPoints,
+  initDefaultJourneyPattern,
 }: StopPointsEditorProps) => {
   const keys = useUniqueKeys(pointsInSequence);
   const { formatMessage } = useIntl();
@@ -30,7 +30,7 @@ export const GenericStopPointsEditor = ({
   useEffect(() => {
     // if map isn't enabled, let's produce two empty stop points
     if (!isMapEnabled && pointsInSequence?.length === 0) {
-      initStopPoints();
+      initDefaultJourneyPattern();
     }
   }, []);
 

--- a/src/components/StopPointsEditor/MixedFlexible/MixedFlexibleStopPointsEditor.tsx
+++ b/src/components/StopPointsEditor/MixedFlexible/MixedFlexibleStopPointsEditor.tsx
@@ -5,6 +5,7 @@ import StopPoint from 'model/StopPoint';
 import { useIntl } from 'react-intl';
 import { StopPointsEditorProps } from '..';
 import { MixedFlexibleStopPointEditor } from './MixedFlexibleStopPointEditor';
+import { useEffect } from 'react';
 
 export const MixedFlexibleStopPointsEditor = ({
   pointsInSequence,
@@ -12,9 +13,16 @@ export const MixedFlexibleStopPointsEditor = ({
   updateStopPoint,
   deleteStopPoint,
   addStopPoint,
+  initDefaultJourneyPattern,
 }: StopPointsEditorProps) => {
   const keys = useUniqueKeys(pointsInSequence);
   const { formatMessage } = useIntl();
+
+  useEffect(() => {
+    if (pointsInSequence?.length === 0) {
+      initDefaultJourneyPattern();
+    }
+  }, []);
 
   return (
     <section style={{ marginTop: '2em' }}>

--- a/src/components/StopPointsEditor/index.tsx
+++ b/src/components/StopPointsEditor/index.tsx
@@ -16,7 +16,7 @@ export type StopPointsEditorProps = {
   addStopPoint: (quayRef?: string) => void;
   onPointsInSequenceChange: (pointsInSequence: StopPoint[]) => void;
   transportMode?: VEHICLE_MODE;
-  initStopPoints: () => void;
+  initDefaultJourneyPattern: () => void;
 };
 
 export type StopPointsEditor =

--- a/src/ext/Fintraffic/CustomStyle/styles.scss
+++ b/src/ext/Fintraffic/CustomStyle/styles.scss
@@ -854,3 +854,7 @@ section .notices {
   position: relative;
   margin-top: 2rem;
 }
+
+.stop-point-key-info .radio-buttons {
+  margin-right: 1.25rem;
+}

--- a/src/model/JourneyPattern.ts
+++ b/src/model/JourneyPattern.ts
@@ -20,7 +20,7 @@ export const initJourneyPatterns = (): JourneyPattern[] => [
 ];
 
 export const initJourneyPattern = (): JourneyPattern => ({
-  serviceJourneys: [{ id: `new_${createUuid()}`, passingTimes: [{}, {}] }],
+  serviceJourneys: [{ id: `new_${createUuid()}`, passingTimes: [] }],
   pointsInSequence: [],
 });
 

--- a/src/scenes/FlexibleLineEditor/FlexibleLineEditorSteps.tsx
+++ b/src/scenes/FlexibleLineEditor/FlexibleLineEditorSteps.tsx
@@ -52,6 +52,7 @@ const FlexibleLineEditor = (props: Props) => {
                 onDelete={onDelete}
                 spoilPristine={props.spoilPristine}
                 flexibleLineType={props.flexibleLine.flexibleLineType}
+                transportMode={props.flexibleLine.transportMode}
               />
             )}
           </JourneyPatterns>


### PR DESCRIPTION
More side effects uncovered due to https://github.com/entur/enki/pull/1578
Changes in the PR are meant to avoid errors below

When map is enabled, error in a normal line due to presence of excessive passing times:
![Screenshot 2024-10-24 at 11 52 06](https://github.com/user-attachments/assets/37213ed6-68a9-4bb3-a6f5-00feeb36fc92)

In flexible line too:
<img width="1509" alt="Screenshot 2024-10-25 at 9 15 55" src="https://github.com/user-attachments/assets/9ab46e45-d698-453c-b3c9-2f32f1511ea4">
