### PR TITLE
Show logged-in user's email even when there are no providers available

### DIFF
--- a/src/scenes/App/NavBar/UserPreference/index.tsx
+++ b/src/scenes/App/NavBar/UserPreference/index.tsx
@@ -3,14 +3,19 @@ import { SelectProvider } from '../../SelectProvider/SelectProvider';
 import { Contrast } from '@entur/layout';
 import './styles.scss';
 import { useNoSelectedProvider } from '../../useNoSelectedProvider';
+import Provider from '../../../../model/Provider';
 
-const UserPreference = () => {
+type UserPreferenceProps = {
+  providers: Provider[] | undefined;
+};
+
+const UserPreference = ({ providers }: UserPreferenceProps) => {
   const noSelectedProvider = useNoSelectedProvider();
 
   return (
     <div className="user-preference">
       <UserMenu />
-      {!noSelectedProvider && (
+      {providers && providers.length > 0 && !noSelectedProvider && (
         <Contrast>
           <SelectProvider />
         </Contrast>

--- a/src/scenes/App/NavBar/index.tsx
+++ b/src/scenes/App/NavBar/index.tsx
@@ -88,7 +88,7 @@ const NavBar = () => {
           />
         </Link>
 
-        {providers && providers.length > 0 && <UserPreference />}
+        <UserPreference providers={providers} />
 
         {active && (
           <>


### PR DESCRIPTION
When no providers available, that affects logged-in user's email not being shown

<img width="1512" alt="Screenshot 2024-10-21 at 15 05 41" src="https://github.com/user-attachments/assets/1f76a3a9-b3a8-4b0c-a285-85da29469859">
