### PR TITLE
fix: not possible to use useUniqueKeys for stop points in sequence

### DIFF
--- a/src/components/JourneyPatternEditor/index.tsx
+++ b/src/components/JourneyPatternEditor/index.tsx
@@ -14,6 +14,7 @@ import './styles.scss';
 import { useConfig } from '../../config/ConfigContext';
 import { VEHICLE_MODE } from '../../model/enums';
 import ServiceJourney from '../../model/ServiceJourney';
+import { createUuid } from '../../helpers/generators';
 
 type Props = {
   journeyPattern: JourneyPattern;
@@ -78,9 +79,11 @@ const JourneyPatternEditor = ({
         passingTimes: [...serviceJourney.passingTimes, {}],
       }));
 
+      const key = createUuid();
+
       let newPointsInSequence = [
         ...journeyPattern.pointsInSequence,
-        quayRef && quayRef ? { quayRef } : {},
+        quayRef && quayRef ? { quayRef, key } : { key },
       ];
 
       onSave({
@@ -102,9 +105,11 @@ const JourneyPatternEditor = ({
           }),
         );
 
+      const key = createUuid();
+
       let newPointsInSequence = [
         ...journeyPatternRef.current.journeyPattern.pointsInSequence,
-        quayRef && quayRef ? { quayRef } : {},
+        quayRef && quayRef ? { quayRef, key } : { key },
       ];
 
       onSave({
@@ -124,7 +129,7 @@ const JourneyPatternEditor = ({
   const initDefaultJourneyPattern = useCallback(() => {
     onSave({
       ...journeyPattern,
-      pointsInSequence: [{}, {}],
+      pointsInSequence: [{ key: createUuid() }, { key: createUuid() }],
       serviceJourneys: journeyPattern.serviceJourneys.map(
         (serviceJourney: ServiceJourney) => ({
           ...serviceJourney,

--- a/src/components/StopPointsEditor/Generic/GenericStopPointsEditor.tsx
+++ b/src/components/StopPointsEditor/Generic/GenericStopPointsEditor.tsx
@@ -21,7 +21,6 @@ export const GenericStopPointsEditor = ({
   transportMode,
   initDefaultJourneyPattern,
 }: StopPointsEditorProps) => {
-  const keys = useUniqueKeys(pointsInSequence);
   const { formatMessage } = useIntl();
   const { sandboxFeatures } = useConfig();
   const isMapEnabled = sandboxFeatures?.JourneyPatternStopPointMap;
@@ -53,7 +52,7 @@ export const GenericStopPointsEditor = ({
           )}
           {pointsInSequence.map((stopPoint, pointIndex) => (
             <GenericStopPointEditor
-              key={keys[pointIndex]}
+              key={stopPoint.key}
               order={pointIndex + 1}
               stopPoint={stopPoint}
               spoilPristine={spoilPristine}

--- a/src/model/StopPoint.ts
+++ b/src/model/StopPoint.ts
@@ -20,7 +20,7 @@ type StopPoint = VersionedType & {
 };
 
 export const stopPointToPayload = (stopPoint: StopPoint) => {
-  const { flexibleStopPlace, ...rest } = stopPoint;
+  const { flexibleStopPlace, key, ...rest } = stopPoint;
   return rest;
 };
 

--- a/src/model/StopPoint.ts
+++ b/src/model/StopPoint.ts
@@ -8,6 +8,7 @@ type DestinationDisplay = {
 };
 
 type StopPoint = VersionedType & {
+  key: string;
   flexibleStopPlace?: FlexibleStopPlace;
   flexibleStopPlaceRef?: string | null;
   quayRef?: string | null;

--- a/src/scenes/LineEditor/hooks.ts
+++ b/src/scenes/LineEditor/hooks.ts
@@ -7,6 +7,7 @@ import { Network } from 'model/Network';
 import { useEffect, useState } from 'react';
 import { useMatch, useNavigate } from 'react-router-dom';
 import { useConfig } from '../../config/ConfigContext';
+import { createUuid } from '../../helpers/generators';
 
 export const useUttuErrors = (
   error: ApolloError | undefined,
@@ -63,6 +64,13 @@ export const useLine: UseLineType = () => {
     if (data?.line) {
       setLine({
         ...data?.line,
+        journeyPatterns: data?.line.journeyPatterns?.map((jp) => ({
+          ...jp,
+          pointsInSequence: jp.pointsInSequence.map((pis) => ({
+            ...pis,
+            key: createUuid(),
+          })),
+        })),
         networkRef: data?.line.network?.id,
       });
     }


### PR DESCRIPTION
The equality check in useUniqueKeys does not work correctly for stop points with identical data (quay, boarding/alighting and front texT). Therefore this hook can't be used, but we need to generate a key on the model itself.

Possibly this will also fix #1487 