### PR TITLE
fix: add locale as dependency to boarding type dropdown translations

### DIFF
--- a/src/components/StopPointsEditor/common/BoardingTypeSelect.tsx
+++ b/src/components/StopPointsEditor/common/BoardingTypeSelect.tsx
@@ -43,7 +43,7 @@ export const useOnBoardingTypeChange = (
 };
 
 const useBoardingDropDownItems = () => {
-  const { formatMessage } = useIntl();
+  const { formatMessage, locale } = useIntl();
   const boardingItems = useMemo(
     () => [
       { value: '0', label: formatMessage({ id: 'labelForBoarding' }) },
@@ -53,7 +53,7 @@ const useBoardingDropDownItems = () => {
         label: formatMessage({ id: 'labelForBoardingAndAlighting' }),
       },
     ],
-    [formatMessage],
+    [formatMessage, locale],
   );
 
   return boardingItems;


### PR DESCRIPTION
The boarding/alighting dropdown translations weren't updating when changing language because formatMessage is a stable function. Adding locale as a dependency to useMemo ensures the translations update when the language changes.

Closes #1677 