### PR TITLE
Enable no matches translation for branding field

### DIFF
--- a/src/components/GeneralLineEditor/index.tsx
+++ b/src/components/GeneralLineEditor/index.tsx
@@ -265,6 +265,9 @@ export default <T extends Line>({
             })
           }
           label={formatMessage({ id: 'brandingsDropdownLabelText' })}
+          noMatchesText={formatMessage({
+            id: 'dropdownNoMatchesText',
+          })}
         />
 
         {isFlexibleLine && (

--- a/src/ext/Fintraffic/CustomStyle/styles.scss
+++ b/src/ext/Fintraffic/CustomStyle/styles.scss
@@ -1069,3 +1069,10 @@ section .notices {
 .stop-point-key-info .radio-buttons {
   margin-right: 1.25rem;
 }
+
+.branding-form .required-input {
+  margin-bottom: 3rem;
+}
+.branding-form .form-section {
+  margin-bottom: 3rem;
+}


### PR DESCRIPTION
<img width="568" alt="Screenshot 2025-03-07 at 10 21 24" src="https://github.com/user-attachments/assets/4fc5c608-92ce-443a-908f-a744da5dd4c1" />
