### PR TITLE
Configurable optional public code on line

### DIFF
--- a/.github/environments/dev.json
+++ b/.github/environments/dev.json
@@ -10,5 +10,6 @@
   },
   "supportedFlexibleLineTypes": ["mixedFlexible", "flexibleAreasOnly", "fixed"],
   "sentryDSN": "https://cc3cacbc67234cc7bfe1cf391010414b@o209253.ingest.sentry.io/1769954",
-  "exportGenerateServiceLinksDefault": true
+  "exportGenerateServiceLinksDefault": true,
+  "optionalPublicCodeOnLine": true
 }

--- a/.github/environments/prod.json
+++ b/.github/environments/prod.json
@@ -10,5 +10,6 @@
   },
   "supportedFlexibleLineTypes": ["mixedFlexible", "flexibleAreasOnly", "fixed"],
   "sentryDSN": "https://cc3cacbc67234cc7bfe1cf391010414b@o209253.ingest.sentry.io/1769954",
-  "exportGenerateServiceLinksDefault": false
+  "exportGenerateServiceLinksDefault": false,
+  "optionalPublicCodeOnLine": true
 }

--- a/.github/environments/test.json
+++ b/.github/environments/test.json
@@ -10,5 +10,6 @@
   },
   "supportedFlexibleLineTypes": ["mixedFlexible", "flexibleAreasOnly", "fixed"],
   "sentryDSN": "https://cc3cacbc67234cc7bfe1cf391010414b@o209253.ingest.sentry.io/1769954",
-  "exportGenerateServiceLinksDefault": false
+  "exportGenerateServiceLinksDefault": false,
+  "optionalPublicCodeOnLine": true
 }

--- a/src/components/GeneralLineEditor/index.tsx
+++ b/src/components/GeneralLineEditor/index.tsx
@@ -129,6 +129,8 @@ export default <T extends Line>({
     [brandings],
   );
 
+  const config = useConfig();
+
   return (
     <div className="lines-editor-general">
       <Heading1> {formatMessage({ id: 'editorAbout' })}</Heading1>
@@ -162,7 +164,12 @@ export default <T extends Line>({
         />
 
         <TextField
-          label={formatMessage({ id: 'generalPublicCodeFormGroupTitle' })}
+          label={formatMessage(
+            { id: 'generalPublicCodeFormGroupTitle' },
+            {
+              requiredMarker: !config.optionalPublicCodeOnLine ? '*' : '',
+            },
+          )}
           labelTooltip={formatMessage({
             id: 'generalPublicCodeInputLabelTooltip',
           })}
@@ -176,7 +183,7 @@ export default <T extends Line>({
           }
           {...getErrorFeedback(
             formatMessage({ id: 'publicCodeEmpty' }),
-            !isBlank(line.publicCode),
+            !isBlank(line.publicCode) || !!config.optionalPublicCodeOnLine,
             publicCodePristine,
           )}
         />

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -119,4 +119,9 @@ export interface Config {
    * Supported line modes
    */
   lineSupportedVehicleModes?: VEHICLE_MODE[];
+
+  /**
+   * Make public code on line optional
+   */
+  optionalPublicCodeOnLine?: boolean;
 }

--- a/src/helpers/validation.ts
+++ b/src/helpers/validation.ts
@@ -18,8 +18,12 @@ import StopPoint from 'model/StopPoint';
 import moment from 'moment';
 import { IntlShape } from 'react-intl';
 
-export const validLine = (line: Line, intl: IntlShape): boolean =>
-  aboutLineStepIsValid(line) &&
+export const validLine = (
+  line: Line,
+  intl: IntlShape,
+  optionalPublicCode?: boolean,
+): boolean =>
+  aboutLineStepIsValid(line, optionalPublicCode) &&
   line.journeyPatterns!.every(
     (jp) =>
       validJourneyPattern(jp) && validServiceJourneys(jp.serviceJourneys, intl),
@@ -41,8 +45,9 @@ export const getMaxAllowedStepIndex = (line: Line, intl: IntlShape) => {
 export const getMaxAllowedFlexibleLineStepIndex = (
   line: FlexibleLine,
   intl: IntlShape,
+  optionalPublicCode?: boolean,
 ) => {
-  if (!aboutFlexibleLineStepIsValid(line)) return 0;
+  if (!aboutFlexibleLineStepIsValid(line, optionalPublicCode)) return 0;
   else if (
     line.journeyPatterns!.some(
       (jp) => !validFlexibleLineJourneyPattern(jp, line.flexibleLineType),
@@ -62,8 +67,9 @@ export const currentStepIsValid = (
   currentStep: number,
   line: Line,
   intl: IntlShape,
+  optionalPublicCode?: boolean,
 ) => {
-  if (currentStep === 0) return aboutLineStepIsValid(line);
+  if (currentStep === 0) return aboutLineStepIsValid(line, optionalPublicCode);
   else if (currentStep === 1)
     return line.journeyPatterns!.every((jp) => validJourneyPattern(jp));
   else if (currentStep === 2)
@@ -78,8 +84,10 @@ export const currentFlexibleLineStepIsValid = (
   currentStep: number,
   line: FlexibleLine,
   intl: IntlShape,
+  optionalPublicCode?: boolean,
 ) => {
-  if (currentStep === 0) return aboutFlexibleLineStepIsValid(line);
+  if (currentStep === 0)
+    return aboutFlexibleLineStepIsValid(line, optionalPublicCode);
   else if (currentStep === 1)
     return line.journeyPatterns!.every((jp) =>
       validFlexibleLineJourneyPattern(jp, line.flexibleLineType),
@@ -92,9 +100,12 @@ export const currentFlexibleLineStepIsValid = (
   else return false;
 };
 
-export const aboutLineStepIsValid = (line: Line): boolean =>
+export const aboutLineStepIsValid = (
+  line: Line,
+  optionalPublicCode?: boolean,
+): boolean =>
   !isBlank(line.name) &&
-  !isBlank(line.publicCode) &&
+  (!isBlank(line.publicCode) || !!optionalPublicCode) &&
   !isBlank(line.operatorRef) &&
   !isBlank(line.networkRef) &&
   !isBlank(line.transportMode) &&
@@ -103,16 +114,21 @@ export const aboutLineStepIsValid = (line: Line): boolean =>
 export const validFlexibleLine = (
   line: FlexibleLine,
   intl: IntlShape,
+  optionalPublicCode?: boolean,
 ): boolean =>
-  aboutFlexibleLineStepIsValid(line) &&
+  aboutFlexibleLineStepIsValid(line, optionalPublicCode) &&
   line.journeyPatterns!.every(
     (jp) =>
       validFlexibleLineJourneyPattern(jp, line.flexibleLineType) &&
       validServiceJourneys(jp.serviceJourneys, intl),
   );
 
-export const aboutFlexibleLineStepIsValid = (line: FlexibleLine): boolean =>
-  aboutLineStepIsValid(line) && !isBlank(line.flexibleLineType);
+export const aboutFlexibleLineStepIsValid = (
+  line: FlexibleLine,
+  optionalPublicCode?: boolean,
+): boolean =>
+  aboutLineStepIsValid(line, optionalPublicCode) &&
+  !isBlank(line.flexibleLineType);
 
 export const validJourneyPattern = (
   journeyPatterns?: JourneyPattern,

--- a/src/i18n/translations/en.ts
+++ b/src/i18n/translations/en.ts
@@ -230,7 +230,7 @@ export const messages: MessagesKey = {
   generalPrivateCodeFormGroupTitle: 'Private code',
   generalPrivateCodeInputLabelTooltip:
     'Private code is what identifies the line internally for the operator',
-  generalPublicCodeFormGroupTitle: 'Public code *',
+  generalPublicCodeFormGroupTitle: 'Public code {requiredMarker}',
   generalPublicCodeInputLabelTooltip:
     'Public code is what identifies the line externally towards travellers',
   generalTypeFormGroupTitle: 'Flexible line type *',

--- a/src/i18n/translations/fi.ts
+++ b/src/i18n/translations/fi.ts
@@ -229,7 +229,7 @@ export const messages = {
   generalPrivateCodeFormGroupTitle: 'Yksityinen tunnus',
   generalPrivateCodeInputLabelTooltip:
     'Yksityinen tunnus on se, mikä tunnistaa linjan sisäisesti operaattorille',
-  generalPublicCodeFormGroupTitle: 'Julkinen tunnus *',
+  generalPublicCodeFormGroupTitle: 'Julkinen tunnus {requiredMarker}',
   generalPublicCodeInputLabelTooltip:
     'Julkinen tunnus on se, mikä tunnistaa linjan ulkoisesti matkustajille',
   generalTypeFormGroupTitle: 'Joustavan linjan tyyppi *',

--- a/src/i18n/translations/nb.ts
+++ b/src/i18n/translations/nb.ts
@@ -227,7 +227,7 @@ export const messages = {
   generalPrivateCodeFormGroupTitle: 'Privat kode',
   generalPrivateCodeInputLabelTooltip:
     'Privat kode er det som kjennetegner linjen internt hos en operatør',
-  generalPublicCodeFormGroupTitle: 'Publikumskode *',
+  generalPublicCodeFormGroupTitle: 'Publikumskode {requiredMarker}',
   generalPublicCodeInputLabelTooltip:
     'Publikumskode er det som kjennetegner linjen ut mot publikum',
   generalTypeFormGroupTitle: 'Fleksibel linje-type *',

--- a/src/i18n/translations/sv.ts
+++ b/src/i18n/translations/sv.ts
@@ -226,7 +226,7 @@ export const messages = {
   generalPrivateCodeFormGroupTitle: 'Privat kod',
   generalPrivateCodeInputLabelTooltip:
     'Privat kod är det som kännetecknar linjen internt hos en operatör',
-  generalPublicCodeFormGroupTitle: 'Offentlig kod *',
+  generalPublicCodeFormGroupTitle: 'Offentlig kod {requiredMarker}',
   generalPublicCodeInputLabelTooltip:
     'Offentlig kod är det som kännetecknar linjen ut mot kunder',
   generalTypeFormGroupTitle: 'Flexibel linje-typ *',

--- a/src/scenes/FlexibleLineEditor/index.tsx
+++ b/src/scenes/FlexibleLineEditor/index.tsx
@@ -22,6 +22,7 @@ import FlexibleLineEditorSteps from './FlexibleLineEditorSteps';
 import { useLoadDependencies } from './hooks';
 import { FLEXIBLE_LINE_STEPS } from './steps';
 import './styles.scss';
+import { useConfig } from '../../config/ConfigContext';
 
 const EditorFrame = () => {
   const params = useParams();
@@ -94,6 +95,8 @@ const EditorFrame = () => {
   const authoritiesMissing =
     organisations && filterAuthorities(organisations).length === 0;
 
+  const config = useConfig();
+
   return (
     <Page
       backButtonTitle={
@@ -119,11 +122,24 @@ const EditorFrame = () => {
                   formatMessage({ id: step }),
                 )}
                 isValidStepIndex={(i: number) =>
-                  getMaxAllowedFlexibleLineStepIndex(line!, intl) >= i
+                  getMaxAllowedFlexibleLineStepIndex(
+                    line!,
+                    intl,
+                    config.optionalPublicCodeOnLine,
+                  ) >= i
                 }
-                isLineValid={validFlexibleLine(line!, intl)}
+                isLineValid={validFlexibleLine(
+                  line!,
+                  intl,
+                  config.optionalPublicCodeOnLine,
+                )}
                 currentStepIsValid={(i) =>
-                  currentFlexibleLineStepIsValid(i, line, intl)
+                  currentFlexibleLineStepIsValid(
+                    i,
+                    line,
+                    intl,
+                    config.optionalPublicCodeOnLine,
+                  )
                 }
                 setNextClicked={setNextClicked}
                 isEdit={isEdit}

--- a/src/scenes/LineEditor/index.tsx
+++ b/src/scenes/LineEditor/index.tsx
@@ -22,6 +22,7 @@ import LineEditorSteps from './LineEditorSteps';
 import { FIXED_LINE_STEPS } from './constants';
 import { useLine, useUttuErrors } from './hooks';
 import './styles.scss';
+import { useConfig } from '../../config/ConfigContext';
 
 export default () => {
   const intl = useIntl();
@@ -116,6 +117,8 @@ export default () => {
   const authoritiesMissing =
     organisations && filterAuthorities(organisations).length === 0;
 
+  const config = useConfig();
+
   return (
     <Page
       backButtonTitle={formatMessage({ id: 'navBarLinesMenuItemLabel' })}
@@ -132,8 +135,19 @@ export default () => {
             isValidStepIndex={(i: number) =>
               getMaxAllowedStepIndex(line!, intl) >= i
             }
-            currentStepIsValid={(i) => currentStepIsValid(i, line!, intl)}
-            isLineValid={line ? validLine(line, intl) : false}
+            currentStepIsValid={(i) =>
+              currentStepIsValid(
+                i,
+                line!,
+                intl,
+                config.optionalPublicCodeOnLine,
+              )
+            }
+            isLineValid={
+              line
+                ? validLine(line, intl, config.optionalPublicCodeOnLine)
+                : false
+            }
             setNextClicked={setNextClicked}
             isEdit={!isBlank(match?.params.id)}
             spoilPristine={nextClicked}


### PR DESCRIPTION
https://github.com/entur/uttu/pull/582 made public code optional on lines in graphql. Is is already optional in nordic netex profile. This PR makes it possible to set the UI form field to optional for public code on line, configurable via config property `optionalPublicCodeOnLine`. Default behavior is that it is still required.