### PR TITLE
fix: preserve individual stop point properties when updating booking arrangements

### DIFF
--- a/src/components/StopPointsEditor/FlexibleAreasOnly/FlexibleAreasOnlyStopPointsEditor.tsx
+++ b/src/components/StopPointsEditor/FlexibleAreasOnly/FlexibleAreasOnlyStopPointsEditor.tsx
@@ -21,21 +21,27 @@ export const FlexibleAreasOnlyStopPointsEditor = ({
 
   const onStopPointUpdate = useCallback(
     (updatedStopPoint: StopPoint) => {
+      const [firstPoint, secondPoint] = pointsInSequence;
       onPointsInSequenceChange([
         {
-          ...updatedStopPoint,
+          ...firstPoint,
+          flexibleStopPlaceRef: updatedStopPoint.flexibleStopPlaceRef,
+          destinationDisplay: updatedStopPoint.destinationDisplay,
+          bookingArrangement: updatedStopPoint.bookingArrangement,
           forAlighting: false,
           forBoarding: true,
         },
         {
-          ...updatedStopPoint,
+          ...secondPoint,
+          flexibleStopPlaceRef: updatedStopPoint.flexibleStopPlaceRef,
+          bookingArrangement: updatedStopPoint.bookingArrangement,
           forAlighting: true,
           forBoarding: false,
           destinationDisplay: undefined,
         },
       ]);
     },
-    [onPointsInSequenceChange],
+    [onPointsInSequenceChange, pointsInSequence],
   );
 
   return (


### PR DESCRIPTION
Fixed issue where saving booking arrangements in flexible area only stop points would overwrite all properties on both points instead of preserving existing data while updating only the relevant fields.