### PR TITLE
Fix Dart Sass 3.0 deprecation warnings

### DIFF
--- a/src/components/BookingArrangementEditor/styles.scss
+++ b/src/components/BookingArrangementEditor/styles.scss
@@ -1,4 +1,4 @@
-@import '@entur/tokens/dist/styles.scss';
+@use '@entur/tokens/dist/styles.scss' as *;
 
 .booking-info {
   margin-top: 2rem;

--- a/src/components/DayTypesEditor/styles.scss
+++ b/src/components/DayTypesEditor/styles.scss
@@ -1,4 +1,4 @@
-@import '@entur/tokens/dist/styles.scss';
+@use '@entur/tokens/dist/styles.scss' as *;
 
 .day-types-modal_new-day-type-button {
   padding: $space-large;

--- a/src/components/FlexibleLineTypeSelector/styles.scss
+++ b/src/components/FlexibleLineTypeSelector/styles.scss
@@ -1,4 +1,4 @@
-@import '@entur/tokens/dist/styles.scss';
+@use '@entur/tokens/dist/styles.scss' as *;
 
 .line-type-dropdown {
   width: 100%;

--- a/src/components/GeneralLineEditor/styles.scss
+++ b/src/components/GeneralLineEditor/styles.scss
@@ -1,4 +1,4 @@
-@import '@entur/tokens/dist/styles.scss';
+@use '@entur/tokens/dist/styles.scss' as *;
 
 .lines-editor-general {
   .header {

--- a/src/components/JourneyPatternEditor/General/styles.scss
+++ b/src/components/JourneyPatternEditor/General/styles.scss
@@ -1,4 +1,4 @@
-@import '@entur/tokens/dist/styles';
+@use '@entur/tokens/dist/styles' as *;
 
 .journey-pattern-inputs {
   display: flex;

--- a/src/components/JourneyPatternEditor/styles.scss
+++ b/src/components/JourneyPatternEditor/styles.scss
@@ -1,4 +1,4 @@
-@import '@entur/tokens/dist/styles.scss';
+@use '@entur/tokens/dist/styles.scss' as *;
 
 .journey-pattern-editor {
   display: flex;

--- a/src/components/LineEditorStepper/styles.scss
+++ b/src/components/LineEditorStepper/styles.scss
@@ -1,4 +1,4 @@
-@import '@entur/tokens/dist/styles.scss';
+@use '@entur/tokens/dist/styles.scss' as *;
 
 .line-editor {
   .step-errors {

--- a/src/components/Loading/styles.scss
+++ b/src/components/Loading/styles.scss
@@ -1,4 +1,4 @@
-@import '@entur/tokens/dist/styles.scss';
+@use '@entur/tokens/dist/styles.scss' as *;
 
 .loader {
   display: none;

--- a/src/components/Notification/styles.scss
+++ b/src/components/Notification/styles.scss
@@ -1,4 +1,4 @@
-@import '@entur/tokens/dist/styles.scss';
+@use '@entur/tokens/dist/styles.scss' as *;
 
 .notification {
   position: fixed;

--- a/src/components/OverlayLoader/styles.scss
+++ b/src/components/OverlayLoader/styles.scss
@@ -1,4 +1,4 @@
-@import '@entur/tokens/dist/styles.scss';
+@use '@entur/tokens/dist/styles.scss' as *;
 
 .overlay-loader {
   position: relative;

--- a/src/components/Page/styles.scss
+++ b/src/components/Page/styles.scss
@@ -1,4 +1,4 @@
-@import '@entur/tokens/dist/styles.scss';
+@use '@entur/tokens/dist/styles.scss' as *;
 
 .page {
   .back-button {

--- a/src/components/PassingTimesEditor/styles.scss
+++ b/src/components/PassingTimesEditor/styles.scss
@@ -1,4 +1,4 @@
-@import '@entur/tokens/dist/styles.scss';
+@use '@entur/tokens/dist/styles.scss' as *;
 
 .passing-times-editor {
   .passing-time {

--- a/src/components/ServiceJourneyEditor/styles.scss
+++ b/src/components/ServiceJourneyEditor/styles.scss
@@ -1,4 +1,4 @@
-@import '@entur/tokens/dist/styles.scss';
+@use '@entur/tokens/dist/styles.scss' as *;
 
 .service-journey-editor {
   display: flex;

--- a/src/components/ServiceJourneys/styles.scss
+++ b/src/components/ServiceJourneys/styles.scss
@@ -1,4 +1,4 @@
-@import '@entur/tokens/dist/styles.scss';
+@use '@entur/tokens/dist/styles.scss' as *;
 
 .modal {
   display: flex;

--- a/src/components/StopPointsEditor/styles.scss
+++ b/src/components/StopPointsEditor/styles.scss
@@ -1,4 +1,4 @@
-@import '@entur/tokens/dist/styles.scss';
+@use '@entur/tokens/dist/styles.scss' as *;
 
 .stop-point-editor-container {
   display: flex;

--- a/src/components/TimeUnitPicker/styles.scss
+++ b/src/components/TimeUnitPicker/styles.scss
@@ -1,4 +1,4 @@
-@import '@entur/tokens/dist/styles.scss';
+@use '@entur/tokens/dist/styles.scss' as *;
 
 .time-unit-picker {
   position: relative;

--- a/src/ext/JourneyPatternStopPointMap/Popovers/styles.scss
+++ b/src/ext/JourneyPatternStopPointMap/Popovers/styles.scss
@@ -1,4 +1,4 @@
-@import '../../../../node_modules/@entur/tokens/dist/styles';
+@use '../../../../node_modules/@entur/tokens/dist/styles' as *;
 
 .search-popover {
   position: absolute;

--- a/src/scenes/App/NavBar/Logo/styles.scss
+++ b/src/scenes/App/NavBar/Logo/styles.scss
@@ -1,4 +1,4 @@
-@import '../../../../../node_modules/@entur/tokens/dist/styles';
+@use '../../../../../node_modules/@entur/tokens/dist/styles' as *;
 
 .logo {
   width: 72px;

--- a/src/scenes/App/NavBar/UserPreference/UserMenu/styles.scss
+++ b/src/scenes/App/NavBar/UserPreference/UserMenu/styles.scss
@@ -1,4 +1,4 @@
-@import '../../../../../../node_modules/@entur/tokens/dist/styles';
+@use '../../../../../../node_modules/@entur/tokens/dist/styles' as *;
 
 .user-menu {
   font-size: 16px;

--- a/src/scenes/App/NavBar/styles.scss
+++ b/src/scenes/App/NavBar/styles.scss
@@ -1,4 +1,4 @@
-@import '../../../../node_modules/@entur/tokens/dist/styles';
+@use '../../../../node_modules/@entur/tokens/dist/styles' as *;
 
 .navbar-wrapper {
   left: 0;

--- a/src/scenes/App/styles.scss
+++ b/src/scenes/App/styles.scss
@@ -1,4 +1,4 @@
-@import '@entur/tokens/dist/styles.scss';
+@use '@entur/tokens/dist/styles.scss' as *;
 
 .app {
   .navbar-and-routes {

--- a/src/scenes/Brandings/styles.scss
+++ b/src/scenes/Brandings/styles.scss
@@ -1,4 +1,4 @@
-@import '@entur/tokens/dist/styles.scss';
+@use '@entur/tokens/dist/styles.scss' as *;
 
 .brandings {
   flex: 1;

--- a/src/scenes/Exports/Creator/styles.scss
+++ b/src/scenes/Exports/Creator/styles.scss
@@ -1,4 +1,4 @@
-@import '../../../../node_modules/@entur/tokens/dist/styles';
+@use '../../../../node_modules/@entur/tokens/dist/styles' as *;
 
 .export-editor {
   flex: 1;

--- a/src/scenes/Exports/Viewer/styles.scss
+++ b/src/scenes/Exports/Viewer/styles.scss
@@ -1,4 +1,4 @@
-@import '../../../../node_modules/@entur/tokens/dist/styles';
+@use '../../../../node_modules/@entur/tokens/dist/styles' as *;
 
 .export-viewer {
   flex: 1;

--- a/src/scenes/Exports/icons/styles.scss
+++ b/src/scenes/Exports/icons/styles.scss
@@ -1,4 +1,4 @@
-@import '@entur/tokens/dist/styles.scss';
+@use '@entur/tokens/dist/styles.scss' as *;
 
 .error-icon {
   color: $colors-validation-lava;

--- a/src/scenes/Exports/styles.scss
+++ b/src/scenes/Exports/styles.scss
@@ -1,4 +1,4 @@
-@import '@entur/tokens/dist/styles.scss';
+@use '@entur/tokens/dist/styles.scss' as *;
 @import '@entur/button/dist/styles.css';
 
 .exports {

--- a/src/scenes/FlexibleLineEditor/styles.scss
+++ b/src/scenes/FlexibleLineEditor/styles.scss
@@ -1,4 +1,4 @@
-@import '@entur/tokens/dist/styles.scss';
+@use '@entur/tokens/dist/styles.scss' as *;
 
 .page-content {
   .line-editor {

--- a/src/scenes/LineEditor/styles.scss
+++ b/src/scenes/LineEditor/styles.scss
@@ -1,4 +1,4 @@
-@import '@entur/tokens/dist/styles.scss';
+@use '@entur/tokens/dist/styles.scss' as *;
 
 .page-content {
   .line-editor {

--- a/src/scenes/Networks/styles.scss
+++ b/src/scenes/Networks/styles.scss
@@ -1,4 +1,4 @@
-@import '@entur/tokens/dist/styles.scss';
+@use '@entur/tokens/dist/styles.scss' as *;
 
 .networks {
   flex: 1;

--- a/src/scenes/Providers/styles.scss
+++ b/src/scenes/Providers/styles.scss
@@ -1,4 +1,4 @@
-@import '@entur/tokens/dist/styles.scss';
+@use '@entur/tokens/dist/styles.scss' as *;
 
 .providers {
   flex: 1;

--- a/src/scenes/StopPlaces/scenes/Editor/styles.scss
+++ b/src/scenes/StopPlaces/scenes/Editor/styles.scss
@@ -1,4 +1,4 @@
-@import '@entur/tokens/dist/styles.scss';
+@use '@entur/tokens/dist/styles.scss' as *;
 
 .stop-place-editor {
   .stop-place-form-container {

--- a/src/styles/base/base.scss
+++ b/src/styles/base/base.scss
@@ -1,3 +1,5 @@
+@use '@entur/tokens/dist/styles.scss' as *;
+
 body {
   margin: 0;
   padding: 0;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,4 +1,6 @@
-@import '@entur/tokens/dist/styles.scss';
+@use '@entur/tokens/dist/styles.scss' as *;
+@use './base/base.scss' as *;
+
 @import '@entur/typography/dist/styles.css';
 @import '@entur/dropdown/dist/styles.css';
 @import '@entur/a11y/dist/styles.css';
@@ -14,7 +16,6 @@
 @import '@entur/loader/dist/styles.css';
 @import '@entur/modal/dist/styles.css';
 @import '@entur/grid/dist/styles.css';
-@import './base/base.scss';
 
 .form-section {
   margin-bottom: 30px;


### PR DESCRIPTION
Example warnings:

Deprecation Warning [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

  ╷
1 │ @import '@entur/tokens/dist/styles.scss';
  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ╵
    src/scenes/App/styles.scss 1:9  root stylesheet

Deprecation Warning [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

  ╷
1 │ @import '../../../../../node_modules/@entur/tokens/dist/styles';
  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ╵
    src/scenes/App/NavBar/Logo/styles.scss 1:9  root stylesheet