### PR TITLE
Implementation: Fix Duration Parse Error in Booking Information Modal

### DIFF
--- a/src/components/DurationPicker/index.tsx
+++ b/src/components/DurationPicker/index.tsx
@@ -114,7 +114,7 @@ export default (props: Props) => {
     onChange(
       resetOnZero && Object.values(newDuration).every((val) => val === 0)
         ? undefined
-        : JSON.stringify(newDuration),
+        : durationLib.toString(newDuration),
     );
   };
 


### PR DESCRIPTION
## Summary

- Fix regression from #1696 that caused the booking information modal to crash when changing the minimum booking period
- Replace  with  to output valid ISO 8601 duration strings

## Changes

### DurationPicker Component
- **File**: 
- Changed duration serialization from  to 
- This outputs proper ISO 8601 strings (e.g., ) instead of JSON objects (e.g., )

## Root Cause

The  function was using  to serialize duration values, which produced strings like . When the component re-rendered with this invalid string,  threw a  because it expects ISO 8601 duration strings like .

## Test Plan

- [x] Navigate to a flexible line's booking arrangement editor
- [x] In the "Booking limit" section, select the "Period" radio button
- [x] Change the minimum booking period using the duration picker
- [x] Verify the new value is displayed correctly without page crash
- [x] Verify the duration picker shows the correct values after change
- [x] Navigate to a service journey and open the Copy dialog
- [x] Enable "Multiple" copies option
- [x] Change the interval duration picker
- [x] Verify the value is displayed correctly without errors

## Notes

- The  library's  function was already being used elsewhere in the component for similar serialization, making this a consistent fix
- No migration needed - existing data in the backend is already stored in ISO 8601 format
- This is a one-line fix that restores the behavior from before PR #1696

Fixes #2023

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)