### PR TITLE
Implementation: Fix Duration Parse Error When No Initial Duration Set

### DIFF
--- a/src/components/DurationPicker/index.tsx
+++ b/src/components/DurationPicker/index.tsx
@@ -103,12 +103,12 @@ export default (props: Props) => {
 
   const handleOnUnitChange = (unit: string, value: number) => {
     const newDuration = {
-      seconds: unit === 'seconds' ? value : parsedDuration?.seconds,
-      minutes: unit === 'minutes' ? value : parsedDuration?.minutes,
-      hours: unit === 'hours' ? value : parsedDuration?.hours,
-      days: unit === 'days' ? value : parsedDuration?.days,
-      months: unit === 'months' ? value : parsedDuration?.months,
-      years: unit === 'years' ? value : parsedDuration?.years,
+      seconds: unit === 'seconds' ? value : (parsedDuration?.seconds ?? 0),
+      minutes: unit === 'minutes' ? value : (parsedDuration?.minutes ?? 0),
+      hours: unit === 'hours' ? value : (parsedDuration?.hours ?? 0),
+      days: unit === 'days' ? value : (parsedDuration?.days ?? 0),
+      months: unit === 'months' ? value : (parsedDuration?.months ?? 0),
+      years: unit === 'years' ? value : (parsedDuration?.years ?? 0),
     };
 
     onChange(


### PR DESCRIPTION
## Summary
- Fixes "Property 'years' must be an integer. Received undefined" error in DurationPicker when no initial duration value is set
- Adds nullish coalescing () to default undefined duration properties to 0 before calling 
- Follow-up fix to #2024 which addressed a related but different duration parsing issue

## Changes

### DurationPicker Component

- Modified  function to default all duration properties to 0 when undefined
- Changed from optional chaining () to nullish coalescing () for all six time unit properties: seconds, minutes, hours, days, months, years

## Root Cause

When  is used without an initial  value:
1.  is set to 
2. When a user selects a time unit value,  builds a new duration object
3. Optional chaining () returns  (not ) when  is undefined
4. The  library's  method requires all properties to be integers
5. Passing  values causes the validation error

## Test Plan
- [ ] Open a flexible line editor and navigate to a service journey with booking arrangements
- [ ] Set booking limit type to "Period" (which uses DurationPicker)
- [ ] When no duration is set, select any value (e.g., 5 minutes)
- [ ] Verify no console errors occur
- [ ] Verify the selected duration appears correctly in the UI
- [ ] Verify the duration is saved correctly
- [ ] Change another time unit (e.g., add 2 hours) and verify both values are preserved

## Notes
- This is a follow-up to PR #2024 which fixed a different duration parsing issue (JSON.stringify → durationLib.toString)
- The fix is minimal and surgical - only adds nullish coalescing defaults
- No changes to component API or behavior for pre-populated duration values
- TypeScript compilation and existing tests pass

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)