### PR TITLE
Implementation: Fix SonarQube S4123 - Filter undefined from Promise.all

### DIFF
--- a/src/ext/JourneyPatternStopPointMap/hooks/useRouteGeometry.ts
+++ b/src/ext/JourneyPatternStopPointMap/hooks/useRouteGeometry.ts
@@ -58,17 +58,19 @@ export const useRouteGeometry = (
       fetchRouteGeometry,
       serviceLinksIndex.current,
       mode,
-    );
+    ).filter((promise): promise is Promise<any> => promise !== undefined);
     const newServiceLinkRefs: Record<string, number[][]> = {};
 
     Promise.all(fetchRouteGeometryPromises).then((serviceLinkResponses) => {
       serviceLinkResponses.forEach((data) => {
-        if (!data) {
-          return;
-        }
         const serviceLink = data?.serviceLink as ServiceLink;
-        newServiceLinkRefs[serviceLink.serviceLinkRef] =
-          serviceLink.routeGeometry.coordinates;
+        if (
+          serviceLink?.serviceLinkRef &&
+          serviceLink?.routeGeometry?.coordinates
+        ) {
+          newServiceLinkRefs[serviceLink.serviceLinkRef] =
+            serviceLink.routeGeometry.coordinates;
+        }
       });
 
       serviceLinksIndex.current = {


### PR DESCRIPTION
# PR Description

## Summary

- Fix SonarQube rule S4123 violation by filtering `undefined` values from the promise array before passing to `Promise.all()`
- Add type predicate to narrow array type from `(Promise<any> | undefined)[]` to `Promise<any>[]`
- Simplify response processing by validating API response content instead of checking for filtered-out undefined values

## Changes

### `src/ext/JourneyPatternStopPointMap/hooks/useRouteGeometry.ts`

**Added type-safe filter before Promise.all:**
```typescript
.filter((promise): promise is Promise<any> => promise !== undefined);
```

The `getRouteGeometryFetchPromises` function returns `undefined` for:
- The last point in sequence (no next point to fetch geometry for)
- Points missing `quayRef` or location data
- Points where the service link is already cached

While JavaScript's `Promise.all()` handles non-Promise values (treating them as immediately resolved), SonarQube flags this as a code smell because it suggests unintentional mixed types.

**Simplified response processing:**
- Removed early return check `if (!data) { return; }`
- Added proper validation: `if (serviceLink?.serviceLinkRef && serviceLink?.routeGeometry?.coordinates)`

This is cleaner because we now validate the actual API response content rather than checking for undefined from filtered-out promises.

## Test Plan

- [x] TypeScript compilation passes: `npm run build`
- [x] All 950 tests pass: `npm test`
- [x] Code formatting check passes: `npm run check`
- [ ] SonarQube no longer flags issue [AZmeCuCvuPWA3VN6QFTc](https://sonarcloud.io/project/issues?id=entur_enki&issues=AZmeCuCvuPWA3VN6QFTc&open=AZmeCuCvuPWA3VN6QFTc) after scan
- [ ] Route geometry displays correctly on the journey pattern map
- [ ] No console errors when viewing journey patterns with stop points

## Notes

This is a minimal, targeted fix that:
1. Fixes the SonarQube issue with a type predicate filter
2. Makes the code's intent clearer (only Promises passed to Promise.all)
3. Improves response validation logic

The `.filter()` operation adds negligible overhead - it's a single pass through a small array (number of stop points - 1) and only runs once per effect execution.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)