### PR TITLE
Implementation: Reduce Function Nesting in BulkDeleteDialog

### DIFF
--- a/src/components/ServiceJourneys/BulkDeleteDialog.tsx
+++ b/src/components/ServiceJourneys/BulkDeleteDialog.tsx
@@ -38,6 +38,12 @@ export default (props: Props) => {
 
   const [filterSearch, setFilterSearch] = React.useState('');
 
+  const filterValidSelectedIds = (filteredJourneys: ServiceJourney[]) => {
+    const validIds = new Set(filteredJourneys.map((item) => item.id));
+    return (previousIds: string[]) =>
+      previousIds.filter((id) => validIds.has(id));
+  };
+
   useEffect(() => {
     const textSearchRegex = new RegExp(
       filterSearch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
@@ -47,9 +53,7 @@ export default (props: Props) => {
       (item) => textSearchRegex.test(item.name!) || filterSearch === '',
     );
     setData(filtered);
-    setSelectedIds((s) =>
-      s.filter((id) => filtered.some((item) => item.id === id)),
-    );
+    setSelectedIds(filterValidSelectedIds(filtered));
   }, [filterSearch, serviceJourneys]);
 
   const add = (id: string) => {


### PR DESCRIPTION
## Summary
- Extract nested filtering logic into a helper function to reduce nesting depth from 5 levels to 3
- Resolves SonarQube rule typescript:S2004 (issue AY30zGhCh4tDjPfeKLxP) for excessive function nesting
- Improves performance by using Set for O(1) ID lookup instead of Array.some()

## Changes

### `src/components/ServiceJourneys/BulkDeleteDialog.tsx`
- Added `filterValidSelectedIds` helper function that creates a Set of valid IDs and returns a filter function suitable for the React state updater pattern
- Updated `useEffect` to use the new helper function instead of deeply nested callbacks

**Before:**
```typescript
setSelectedIds((s) =>              // Level 3
  s.filter((id) =>                 // Level 4
    filtered.some((item) =>        // Level 5 ← EXCEEDED LIMIT
      item.id === id
    )
  )
);
```

**After:**
```typescript
const filterValidSelectedIds = (filteredJourneys: ServiceJourney[]) => {
  const validIds = new Set(filteredJourneys.map((item) => item.id));
  return (previousIds: string[]) =>
    previousIds.filter((id) => validIds.has(id));
};

// In useEffect:
setSelectedIds(filterValidSelectedIds(filtered));
```

## Test Plan
- [x] TypeScript compiles without errors (`npm run build`)
- [x] All 950 tests pass (`npm test`)
- [x] Code formatting is correct (`npm run check`)
- [ ] Open the Line Editor, navigate to a journey pattern with multiple service journeys
- [ ] Click "Delete Service Journeys" to open the bulk delete dialog
- [ ] Verify the search filter works correctly (filtering narrows the list)
- [ ] Verify that selecting items and then filtering keeps only visible selections
- [ ] Verify bulk delete functionality completes successfully

## Notes
- This is a pure refactoring with no functional changes
- The new implementation provides a minor performance improvement: O(1) lookup using `Set.has()` instead of O(n) with `.some()`
- Follows the existing pattern in the codebase where helper functions are extracted to reduce nesting (e.g., `LinesForExport/index.tsx`)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)