### PR TITLE
Implementation: Fix Empty Object Pattern in helpers.ts

### DIFF
--- a/src/ext/JourneyPatternStopPointMap/helpers.ts
+++ b/src/ext/JourneyPatternStopPointMap/helpers.ts
@@ -233,7 +233,7 @@ export const getServiceLinkRef = (quayRefFrom: string, quayRefTo: string) => {
 export const getRouteGeometryFetchPromises = (
   pointsInSequence: StopPoint[],
   quayLocationsIndex: Record<string, Centroid>,
-  fetchRouteGeometryFunction: ({}: {
+  fetchRouteGeometryFunction: (params: {
     quayRefFrom: string;
     quayRefTo: string;
     mode: VEHICLE_MODE;


### PR DESCRIPTION
## Summary
- Fix SonarQube issue S3799 "Unexpected empty object pattern" in `helpers.ts`
- Replace empty destructuring pattern `{}` with named parameter `params` in function type declaration
- Type annotation change only with no runtime impact

## Changes

### `src/ext/JourneyPatternStopPointMap/helpers.ts`
- **Line 236**: Changed `fetchRouteGeometryFunction: ({}: {...})` to `fetchRouteGeometryFunction: (params: {...})`
- The empty destructuring pattern `{}` was syntactically valid but semantically meaningless, triggering SonarQube rule `typescript:S3799`

**Before:**
```typescript
fetchRouteGeometryFunction: ({}: {
  quayRefFrom: string;
  quayRefTo: string;
  mode: VEHICLE_MODE;
}) => Promise<any>,
```

**After:**
```typescript
fetchRouteGeometryFunction: (params: {
  quayRefFrom: string;
  quayRefTo: string;
  mode: VEHICLE_MODE;
}) => Promise<any>,
```

## Test Plan
- [x] TypeScript compilation passes (`npm run build`)
- [x] All 1035 tests pass (`npm test`)
- [ ] Verify SonarQube issue [AZU8xuA6cRK49DKv02E9](https://sonarcloud.io/project/issues?id=entur_enki&issues=AZU8xuA6cRK49DKv02E9&open=AZU8xuA6cRK49DKv02E9) is resolved after merge

## Notes
- This is purely a type annotation change with no functional impact
- The actual callback implementation in `useRouteGeometry.ts` already uses proper named destructuring
- No migration or breaking changes

---
🤖 Generated with [Claude Code](https://claude.ai/code)