### PR TITLE
Implementation: Fix Identical Sub-expressions in JourneyPatternEditor (S1764)

### DIFF
--- a/src/components/JourneyPatternEditor/index.tsx
+++ b/src/components/JourneyPatternEditor/index.tsx
@@ -94,7 +94,7 @@ const JourneyPatternEditor = ({
 
       let newPointsInSequence = [
         ...journeyPattern.pointsInSequence,
-        quayRef && quayRef ? { quayRef, key } : { key },
+        quayRef ? { quayRef, key } : { key },
       ];
 
       onSave({


### PR DESCRIPTION
# PR: Fix Identical Sub-expressions in JourneyPatternEditor (S1764)

## Summary
- Fix SonarQube issue S1764 by removing redundant identical sub-expression `quayRef && quayRef` in JourneyPatternEditor
- Simplify to just `quayRef` to match the existing correct pattern in `addStopPointForMap`

## Changes

### `src/components/JourneyPatternEditor/index.tsx`
- **Line 97**: Changed `quayRef && quayRef ? { quayRef, key } : { key }` to `quayRef ? { quayRef, key } : { key }`

**Before:**
```typescript
quayRef && quayRef ? { quayRef, key } : { key },
```

**After:**
```typescript
quayRef ? { quayRef, key } : { key },
```

## Technical Details

The expression `quayRef && quayRef` was flagged by SonarQube rule [typescript:S1764](https://rules.sonarsource.com/typescript/RSPEC-1764) which detects identical expressions on both sides of binary operators. This is typically a code smell indicating either:
1. A copy-paste error where the second operand should be different
2. Simply redundant code

In this case, the second `quayRef` adds no value since:
- If `quayRef` is truthy, `quayRef && quayRef` returns `quayRef` (same as checking just `quayRef`)
- If `quayRef` is falsy, the expression short-circuits immediately

The correct pattern already existed in the same file in `addStopPointForMap` (line 123), so this fix aligns both functions.

## Test Plan
- [x] TypeScript compilation passes (`npm run build`)
- [x] Unit tests pass (`npm test`)
- [x] Code formatting is correct (`npm run check`)
- [ ] SonarQube no longer reports issue [AZMmSLgUvLIfv2rmGkMJ](https://sonarcloud.io/project/issues?id=entur_enki&issues=AZMmSLgUvLIfv2rmGkMJ&open=AZMmSLgUvLIfv2rmGkMJ)

## Notes
- This is a purely cosmetic fix with no behavioral changes
- The logic remains identical; we're simply removing the redundant duplicate check
- No new tests required as existing tests validate the unchanged behavior

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
