### PR TITLE
Implementation: Fix Unsafe Optional Chaining in LinesForExport

### DIFF
--- a/src/components/LinesForExport/index.tsx
+++ b/src/components/LinesForExport/index.tsx
@@ -86,8 +86,8 @@ export default ({ onChange }: Props) => {
   useEffect(() => {
     if (data) {
       setLines([
-        ...data?.lines.map(mapLine),
-        ...data?.flexibleLines.map(mapLine),
+        ...data.lines.map(mapLine),
+        ...data.flexibleLines.map(mapLine),
       ]);
     }
   }, [data]);


### PR DESCRIPTION
## Summary
- Remove redundant optional chaining operators (`?.`) inside a guarded `if (data)` block in the `LinesForExport` component
- Resolves SonarQube issue typescript:S6523 (unsafe usage of optional chaining)

## Changes

### `src/components/LinesForExport/index.tsx`
- Replaced `data?.lines.map(mapLine)` with `data.lines.map(mapLine)` on line 89
- Replaced `data?.flexibleLines.map(mapLine)` with `data.flexibleLines.map(mapLine)` on line 90

### Why this change is safe
The optional chaining was redundant because:
1. The code is inside an `if (data)` guard block, which narrows `data` from `LinesData | undefined` to `LinesData`
2. The `LinesData` type explicitly defines both `lines` and `flexibleLines` as non-nullable arrays (`Line[]` and `FlexibleLine[]`)
3. Within the guarded block, TypeScript guarantees these properties are defined arrays

## Test Plan
- [x] TypeScript compilation passes (`npm run build`)
- [x] All existing tests pass (`npm test`)
- [x] Code formatting is correct (`npm run check`)
- [ ] Navigate to the exports page and verify lines load correctly
- [ ] Verify that selecting/deselecting lines works as expected
- [ ] Confirm no runtime errors in browser console

## Notes
This is a pure refactoring change with no behavioral difference. The optional chaining operators were flagged by SonarQube's static analysis because if they short-circuited to `undefined`, the spread operator (`...undefined`) would throw a `TypeError`. However, since the code is inside a guard block, this scenario cannot occur.

**SonarQube Issue**: [AYcyEOyNNMAZ5G7EGA5r](https://sonarcloud.io/project/issues?id=entur_enki&issues=AYcyEOyNNMAZ5G7EGA5r&open=AYcyEOyNNMAZ5G7EGA5r)

---
🤖 Generated with [Claude Code](https://claude.ai/code)