### PR TITLE
Implementation: Fix Conditional React Hook useRouteGeometry

### DIFF
--- a/src/ext/JourneyPatternStopPointMap/JourneyPatternStopPointMap.tsx
+++ b/src/ext/JourneyPatternStopPointMap/JourneyPatternStopPointMap.tsx
@@ -91,16 +91,15 @@ const JourneyPatternStopPointMap = memo(
       !!isRouteGeometryEnabled,
     );
 
-    if (isRouteGeometryEnabled) {
-      // Handling service links data;
-      // If route geometry is enabled, this is where the needed coordinates are set up
-      useRouteGeometry(
-        pointsInSequence,
-        totalQuayLocationsIndex,
-        setMapState,
-        transportMode,
-      );
-    }
+    // Handling service links data;
+    // If route geometry is enabled, this is where the needed coordinates are set up
+    useRouteGeometry(
+      pointsInSequence,
+      totalQuayLocationsIndex,
+      setMapState,
+      transportMode,
+      !!isRouteGeometryEnabled,
+    );
 
     // Zoom into location of a focused marker:
     useMapZoomIntoLocation(mapState.focusedMarker?.marker.location);

--- a/src/ext/JourneyPatternStopPointMap/hooks/useRouteGeometry.ts
+++ b/src/ext/JourneyPatternStopPointMap/hooks/useRouteGeometry.ts
@@ -19,12 +19,14 @@ import StopPoint from '../../../model/StopPoint';
  * @param quayLocationsIndex
  * @param setMapState
  * @param mode
+ * @param enabled
  */
 export const useRouteGeometry = (
   pointsInSequence: StopPoint[],
   quayLocationsIndex: Record<string, Centroid>,
   setMapState: (state: Partial<JourneyPatternsMapState>) => void,
   mode: VEHICLE_MODE,
+  enabled: boolean = true,
 ) => {
   const serviceLinksIndex = useRef<Record<string, number[][]>>({});
   const activeProvider =
@@ -52,6 +54,9 @@ export const useRouteGeometry = (
   };
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
     const fetchRouteGeometryPromises = getRouteGeometryFetchPromises(
       pointsInSequence,
       quayLocationsIndex,
@@ -86,5 +91,5 @@ export const useRouteGeometry = (
         );
       setMapState({ stopPointLocationSequence });
     });
-  }, [pointsInSequence, serviceLinksIndex, quayLocationsIndex]);
+  }, [pointsInSequence, serviceLinksIndex, quayLocationsIndex, enabled]);
 };


### PR DESCRIPTION
## Summary
- Fix React Rules of Hooks violation where `useRouteGeometry` was called conditionally
- Add `enabled` parameter to the hook to control behavior without breaking hook call order
- Resolves SonarQube MAJOR/BUG issue [AZPjraq52F4qIlrUOlkA](https://sonarcloud.io/project/issues?id=entur_enki&issues=AZPjraq52F4qIlrUOlkA&open=AZPjraq52F4qIlrUOlkA)

## Changes

### `src/ext/JourneyPatternStopPointMap/hooks/useRouteGeometry.ts`
- Added `enabled: boolean = true` parameter to hook signature
- Added JSDoc documentation for the new parameter
- Added early return guard inside `useEffect`: `if (!enabled) { return; }`
- Added `enabled` to the `useEffect` dependency array

### `src/ext/JourneyPatternStopPointMap/JourneyPatternStopPointMap.tsx`
- Removed conditional `if (isRouteGeometryEnabled)` wrapper around hook call
- Changed to call `useRouteGeometry` unconditionally, passing `!!isRouteGeometryEnabled` as the `enabled` parameter

## Test Plan
- [x] TypeScript compiles: `npm run build`
- [x] No formatting issues: `npm run check`
- [x] All 1035 tests pass: `npm test`
- [ ] Manual: Map displays correctly with route geometry enabled (use a supported transport mode)
- [ ] Manual: Map displays correctly with route geometry disabled (use an unsupported transport mode)
- [ ] SonarQube scan confirms issue is resolved

## Notes

### Pattern Used
This follows the **conditional guard inside useEffect** pattern that is common throughout this codebase, as seen in:
- `useFitMapBounds.ts`
- `useBoundingBoxedStopPlacesData.ts`
- `useHandleFocusedQuayId.ts`
- And 10+ other hooks

### Performance Considerations
No performance impact - the hook still only makes API calls when `enabled=true`. The only difference is that the internal hooks (`useRef`, `useAppSelector`, `useConfig`, `useAuth`) are now called on every render, but these are lightweight operations that React is optimized for.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)