### PR TITLE
Fix booking information save issues after MUI migration

### DIFF
--- a/src/components/BookingArrangementEditor/editor.tsx
+++ b/src/components/BookingArrangementEditor/editor.tsx
@@ -105,9 +105,9 @@ export default (props: Props) => {
       latestBookingTime: undefined,
       minimumBookingPeriod: undefined,
       bookWhen:
-        type === BOOKING_LIMIT_TYPE.PERIOD
-          ? undefined
-          : bookingArrangement.bookWhen,
+        type === BOOKING_LIMIT_TYPE.TIME
+          ? bookingArrangement.bookWhen
+          : undefined,
     });
     setBookingLimitType(type);
   };

--- a/src/components/BookingArrangementEditor/editor.tsx
+++ b/src/components/BookingArrangementEditor/editor.tsx
@@ -323,7 +323,9 @@ export default (props: Props) => {
                 let formattedDate;
 
                 if (date != null) {
-                  formattedDate = `${date.getHours()}:${date.getMinutes()}`;
+                  const hours = String(date.getHours()).padStart(2, '0');
+                  const minutes = String(date.getMinutes()).padStart(2, '0');
+                  formattedDate = `${hours}:${minutes}`;
                 }
 
                 onLatestBookingTimeChange(formattedDate);

--- a/src/components/BookingArrangementEditor/editor.tsx
+++ b/src/components/BookingArrangementEditor/editor.tsx
@@ -294,9 +294,13 @@ export default (props: Props) => {
           </FormLabel>
           <RadioGroup
             name="booking-limit-type"
-            onChange={(e) =>
-              onBookingLimitTypeChange(e?.target?.value as BOOKING_LIMIT_TYPE)
-            }
+            onChange={(e) => {
+              if ((e.target as HTMLInputElement).type === 'radio') {
+                onBookingLimitTypeChange(
+                  e?.target?.value as BOOKING_LIMIT_TYPE,
+                );
+              }
+            }}
             value={bookingLimitType}
           >
             <FormControlLabel


### PR DESCRIPTION
  Fixes three bugs in the BookingArrangementEditor that surfaced after the MUI migration, all related to saving booking information on flexible lines.
                                                                                                                                                        
###  Issue
                                                                                                                                                        
  Bug 1 – LocalTime validation error: Setting "Latest possible booking time" to midnight (12:00 AM) and saving produces Expected type 'LocalTime' but   
  was '0:0'. The time was formatted without zero-padding (0:0 instead of 00:00).
                                                                                                                                                        
  Bug 2 – Switching booking limit back to "None" prevents saving: Selecting a non-None booking limit and switching back to None left bookWhen set       
  without latestBookingTime, causing a validation error ("Booking information must have booking time or minimum booking period").
                                                                                                                                                        
  Bug 3 – DurationPicker closes immediately: The "minimum period" picker is rendered inside a RadioGroup. Autocomplete change events from the           
  Days/Hours/Minutes dropdowns bubbled up to the RadioGroup's onChange, which interpreted them as booking limit type changes, clearing
  minimumBookingPeriod and disabling the picker.                                                                                                        
                                                                                                                                                      
### Unit tests

  - All 1893 existing tests pass
  - Manual verification needed: create a flexible line (flexible areas only), set booking information with each booking limit type, and confirm saving
  works                                                                                                                                                 
   
###  Documentation                                                                                                                                         
                                                                                                                                                      
  No new configuration or public API. Changes are self-explanatory bug fixes. 