### PR TITLE
Fix latestBookingTime sent as HH:mm instead of HH:mm:ss

### DIFF
--- a/src/components/BookingArrangementEditor/editor.tsx
+++ b/src/components/BookingArrangementEditor/editor.tsx
@@ -329,7 +329,7 @@ export default (props: Props) => {
                 if (date != null) {
                   const hours = String(date.getHours()).padStart(2, '0');
                   const minutes = String(date.getMinutes()).padStart(2, '0');
-                  formattedDate = `${hours}:${minutes}`;
+                  formattedDate = `${hours}:${minutes}:00`;
                 }
 
                 onLatestBookingTimeChange(formattedDate);


### PR DESCRIPTION
The API expects LocalTime format (HH:mm:ss) but the booking arrangement editor was sending HH:mm, causing the backend to reject values like "10:5" instead of "10:05:00".

Fixes #2108
