### PR TITLE
Replace type-specific enum mapper with generic mapEnumMessagesToItems

### DIFF
--- a/src/components/BookingArrangementEditor/BookingArrangementEditor.test.tsx
+++ b/src/components/BookingArrangementEditor/BookingArrangementEditor.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import BookingArrangementEditor from './index';
 import { BookingInfoAttachmentType } from './constants';
 import { createBookingArrangement } from 'test/factories';
+import { PURCHASE_WHEN } from 'model/enums';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 
@@ -81,5 +82,31 @@ describe('BookingArrangementEditor (wrapper)', () => {
     renderEditor({ bookingArrangement: createBookingArrangement() });
     await userEvent.click(screen.getByRole('button', { name: 'Show / Edit' }));
     expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+  });
+
+  it('shows translated label for selected booking access value', async () => {
+    renderEditor({ bookingArrangement: createBookingArrangement() });
+    await userEvent.click(screen.getByRole('button', { name: 'Show / Edit' }));
+
+    const bookingAccessInput = screen.getByRole('combobox', {
+      name: 'Booking access',
+    });
+    expect(bookingAccessInput).toHaveValue('Public');
+  });
+
+  it('shows translated label for selected purchase when value', async () => {
+    renderEditor({
+      bookingArrangement: createBookingArrangement({
+        bookWhen: PURCHASE_WHEN.ADVANCE_AND_DAY_OF_TRAVEL,
+        minimumBookingPeriod: undefined,
+        latestBookingTime: '08:00:00',
+      }),
+    });
+    await userEvent.click(screen.getByRole('button', { name: 'Show / Edit' }));
+
+    const purchaseWhenInput = screen.getByRole('combobox', {
+      name: 'Booking time',
+    });
+    expect(purchaseWhenInput).toHaveValue('Advance and day of travel');
   });
 });

--- a/src/components/BookingArrangementEditor/editor.tsx
+++ b/src/components/BookingArrangementEditor/editor.tsx
@@ -15,8 +15,7 @@ import { TimeUnitPickerPosition } from 'components/TimeUnitPicker';
 
 import { addOrRemove } from 'helpers/arrays';
 import {
-  getEnumInit,
-  mapEnumToItems,
+  mapEnumMessagesToItems,
   NormalizedDropdownItemType,
 } from 'helpers/dropdown';
 import BookingArrangement from 'model/BookingArrangement';
@@ -27,6 +26,8 @@ import {
   BOOKING_METHOD,
   PURCHASE_MOMENT,
   PURCHASE_WHEN,
+  bookingAccessMessages,
+  bookingTimeMessages,
   bookingMethodMessages,
   paymentTimeMessages,
 } from 'model/enums';
@@ -124,8 +125,19 @@ export default (props: Props) => {
       minimumBookingPeriod: period,
     });
 
-  const bookingAccessItems = mapEnumToItems(BOOKING_ACCESS);
-  const purchaseWhenItems = mapEnumToItems(PURCHASE_WHEN);
+  const bookingAccessItems = mapEnumMessagesToItems(
+    bookingAccessMessages,
+    formatMessage,
+  );
+  const purchaseWhenItems = mapEnumMessagesToItems(
+    bookingTimeMessages,
+    formatMessage,
+  );
+
+  const selectedBookingAccess =
+    bookingAccessItems.find((item) => item.value === bookingAccess) ?? null;
+  const selectedPurchaseWhen =
+    purchaseWhenItems.find((item) => item.value === bookWhen) ?? null;
 
   return (
     <Box>
@@ -213,7 +225,7 @@ export default (props: Props) => {
         <Grid size={{ xs: 12, sm: 6 }}>
           <Autocomplete
             fullWidth
-            value={getEnumInit(bookingAccess)}
+            value={selectedBookingAccess}
             options={bookingAccessItems}
             getOptionLabel={(option: NormalizedDropdownItemType) =>
               option.label
@@ -258,7 +270,7 @@ export default (props: Props) => {
             <Autocomplete
               fullWidth
               disabled={bookingLimitType === BOOKING_LIMIT_TYPE.PERIOD}
-              value={getEnumInit(bookWhen)}
+              value={selectedPurchaseWhen}
               options={purchaseWhenItems}
               getOptionLabel={(option: NormalizedDropdownItemType) =>
                 option.label

--- a/src/components/GeneralLineEditor/index.tsx
+++ b/src/components/GeneralLineEditor/index.tsx
@@ -2,7 +2,7 @@ import { Autocomplete, Box, TextField, Typography } from '@mui/material';
 import {
   NormalizedDropdownItemType,
   mapToItems,
-  mapVehicleModeAndLabelToItems,
+  mapEnumMessagesToItems,
 } from 'helpers/dropdown';
 import BookingArrangementEditor from 'components/BookingArrangementEditor';
 import { BookingInfoAttachmentType } from 'components/BookingArrangementEditor/constants';
@@ -90,7 +90,7 @@ export default <T extends Line>({
 
   const getModeItems = useCallback(
     () =>
-      mapVehicleModeAndLabelToItems(
+      mapEnumMessagesToItems(
         lineSupportedVehicleModes && lineSupportedVehicleModes.length > 0
           ? getSupportedVehicleModeMessages()
           : vehicleModeMessages,

--- a/src/helpers/dropdown.test.ts
+++ b/src/helpers/dropdown.test.ts
@@ -2,13 +2,17 @@ import {
   getInit,
   mapToItems,
   getEnumInit,
+  mapEnumMessagesToItems,
   mapEnumToItems,
-  mapVehicleModeAndLabelToItems,
   mapVehicleSubmodeAndLabelToItems,
   mapFlexibleLineTypeAndLabelToItems,
 } from './dropdown';
 import {
+  BOOKING_ACCESS,
+  PURCHASE_WHEN,
   VEHICLE_MODE,
+  bookingAccessMessages,
+  bookingTimeMessages,
   vehicleModeMessages,
   vehicleSubmodeMessages,
   VEHICLE_SUBMODE_LINK,
@@ -114,18 +118,44 @@ describe('dropdown', () => {
     });
   });
 
-  describe('mapVehicleModeAndLabelToItems', () => {
+  describe('mapEnumMessagesToItems', () => {
+    it('should map booking access values with translated labels', () => {
+      const result = mapEnumMessagesToItems(
+        bookingAccessMessages,
+        mockFormatMessage,
+      );
+
+      expect(result.length).toBe(Object.keys(bookingAccessMessages).length);
+      expect(result).toContainEqual({
+        value: BOOKING_ACCESS.PUBLIC,
+        label: 'translated_bookingAccessPublic',
+      });
+    });
+
+    it('should map purchase when values with translated labels', () => {
+      const result = mapEnumMessagesToItems(
+        bookingTimeMessages,
+        mockFormatMessage,
+      );
+
+      expect(result.length).toBe(Object.keys(bookingTimeMessages).length);
+      expect(result).toContainEqual({
+        value: PURCHASE_WHEN.ADVANCE_AND_DAY_OF_TRAVEL,
+        label: 'translated_purchaseWhenAdvanceAndDayOfTravel',
+      });
+    });
+
     it('should map vehicle modes with translated labels', () => {
-      const result = mapVehicleModeAndLabelToItems(
+      const result = mapEnumMessagesToItems(
         vehicleModeMessages,
         mockFormatMessage,
       );
 
+      expect(result.length).toBe(Object.keys(vehicleModeMessages).length);
       expect(result).toContainEqual({
         value: VEHICLE_MODE.BUS,
         label: 'translated_bus',
       });
-      expect(result.length).toBe(Object.keys(vehicleModeMessages).length);
     });
   });
 

--- a/src/helpers/dropdown.ts
+++ b/src/helpers/dropdown.ts
@@ -7,11 +7,7 @@ export type NormalizedDropdownItemType<ValueType = string> = {
   itemKey?: string;
 };
 import { MessagesKey } from '../i18n/translationKeys';
-import {
-  VEHICLE_MODE,
-  VEHICLE_SUBMODE,
-  vehicleSubmodeMessages,
-} from '../model/enums';
+import { VEHICLE_SUBMODE, vehicleSubmodeMessages } from '../model/enums';
 import { FormatMessage } from 'i18n';
 
 type GenericDropdownItem<E> = {
@@ -57,11 +53,11 @@ export const mapEnumToItems = <E extends Object>(
   })),
 ];
 
-export const mapVehicleModeAndLabelToItems = (
-  e: Record<VEHICLE_MODE, keyof MessagesKey>,
+export const mapEnumMessagesToItems = <E extends string>(
+  messages: Record<E, keyof MessagesKey>,
   formatMessage: FormatMessage,
 ): NormalizedDropdownItemType[] => [
-  ...Object.entries(e).map(([key, label]) => ({
+  ...Object.entries<keyof MessagesKey>(messages).map(([key, label]) => ({
     value: key,
     label: formatMessage({ id: label }),
   })),


### PR DESCRIPTION
## Summary
Replace the type-specific mapVehicleModeAndLabelToItems function with a generic `mapEnumMessagesToItems<E extends string> `that works with any `Record<E, keyof MessagesKey>.` 

## Issue
The BookingArrangementEditor displays raw enum values (e.g., "public", "advanceAndDayOfTravel") instead of translated labels for the Booking Access and Purchase When dropdowns. These fields used `mapEnumToItems` which doesn't translate, while vehicle mode dropdowns already had a translated mapper (`mapVehicleModeAndLabelToItems`).

## Unit tests
Unit tests for `mapEnumMessagesToItems` cover three enum types (booking access, purchase when, vehicle mode) to verify the generic works across different Records.
Integration tests added to `BookingArrangementEditor.test.tsx `verify that translated labels appear in the rendered Autocomplete inputs.