### PR TITLE
Upgrade TypeScript 5.9 → 6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
         "prettier-plugin-organize-imports": "4.3.0",
         "sass": "1.101.0",
         "source-map-explorer": "2.5.3",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "vite": "8.0.16",
         "vite-plugin-svgr": "5.2.0",
         "vitest": "4.1.5",
@@ -6980,9 +6980,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "prettier-plugin-organize-imports": "4.3.0",
     "sass": "1.101.0",
     "source-map-explorer": "2.5.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vite": "8.0.16",
     "vite-plugin-svgr": "5.2.0",
     "vitest": "4.1.5",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "compilerOptions": {
-    "baseUrl": "src",
+    "paths": {
+      "*": ["./src/*"]
+    },
     "target": "ESNext",
     "lib": [
       "dom",
@@ -12,13 +14,12 @@
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "downlevelIteration": true,
     "importHelpers": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "noEmit": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary

Upgrades TypeScript from 5.9.3 to 6.0.3. TS 6 promotes several deprecated `tsconfig` options to hard errors; this migrates them properly instead of suppressing with `ignoreDeprecations`.

### tsconfig changes
- **`moduleResolution: "node"` → `"bundler"`** — the correct mode for a Vite-bundled app (node10 resolution is deprecated in TS 6).
- **`baseUrl: "src"` → `paths: { "*": ["./src/*"] }`** — `baseUrl` is deprecated; `paths` resolve relative to the tsconfig directory in TS 5+. Vite's `resolve.tsconfigPaths` and Vitest continue to resolve the non-relative `src/...` imports.
- **Removed `downlevelIteration`** — unnecessary with `target: "ESNext"` (it only matters when targeting < ES2015).

### Verification
- `npx tsc` — clean
- `npm run build` (`tsc && vite build`) — green, path aliases resolve
- `npx vitest run` — 1897 tests pass (151 files)

No application code changes were required.