### PR TITLE
Feature/add vehicletyperef to servicejourney

### DIFF
--- a/.github/environments/local.json
+++ b/.github/environments/local.json
@@ -14,6 +14,7 @@
   "exportIncludeDatedServiceJourneysDefault": false,
   "disableIncludeDatedServiceJourneysCheckbox": false,
   "optionalPublicCodeOnLine": true,
+  "enableServiceJourneyVehicleTypeRef": true,
   "sandboxFeatures": {
     "JourneyPatternStopPointMap": true
   }

--- a/src/api/uttu/queries.ts
+++ b/src/api/uttu/queries.ts
@@ -165,6 +165,7 @@ export const getFlexibleLineByIdQuery = `
           privateCode,
           publicCode,
           operatorRef,
+          vehicleTypeRef,
           notices { text }
           bookingArrangement { ...bookingArrangementFields },
           passingTimes {
@@ -261,6 +262,7 @@ export const getlineByIdQuery = `
           privateCode,
           publicCode,
           operatorRef,
+          vehicleTypeRef,
           notices { text }
           passingTimes {
             id,
@@ -454,6 +456,7 @@ const LineEditorPage = {
             privateCode
             publicCode
             operatorRef
+            vehicleTypeRef
             notices {
               text
             }

--- a/src/components/ServiceJourneyEditor/ServiceJourneyEditor.test.tsx
+++ b/src/components/ServiceJourneyEditor/ServiceJourneyEditor.test.tsx
@@ -15,7 +15,13 @@ const dayTypesMock = {
 
 const renderEditor = (
   props = {},
-  { preloadedState }: { preloadedState?: Record<string, unknown> } = {},
+  {
+    preloadedState,
+    config,
+  }: {
+    preloadedState?: Record<string, unknown>;
+    config?: Record<string, unknown>;
+  } = {},
 ) => {
   const defaultProps = {
     serviceJourney: createServiceJourney({
@@ -40,7 +46,7 @@ const renderEditor = (
         <ServiceJourneyEditor {...defaultProps} />
       </LocalizationProvider>
     </MockedProvider>,
-    { preloadedState: preloadedState as any },
+    { preloadedState: preloadedState as any, config: config as any },
   );
 };
 
@@ -61,6 +67,51 @@ describe('ServiceJourneyEditor', () => {
     renderEditor();
     expect(screen.getByLabelText('Public code')).toHaveValue('M1');
     expect(screen.getByLabelText('Private code')).toHaveValue('PRV-M1');
+  });
+
+  it('does not render vehicle type field when feature flag is disabled', () => {
+    renderEditor();
+    expect(screen.queryByLabelText('Vehicle type')).not.toBeInTheDocument();
+  });
+
+  it('renders vehicle type field when feature flag is enabled', () => {
+    renderEditor(
+      {
+        serviceJourney: createServiceJourney({
+          name: 'Route with Vehicle Type',
+          vehicleTypeRef: 'bus',
+          passingTimes: [{}, {}],
+        }),
+      },
+      {
+        config: { enableServiceJourneyVehicleTypeRef: true },
+      },
+    );
+    expect(screen.getByLabelText('Vehicle type')).toHaveValue('bus');
+  });
+
+  it('calls onChange when vehicle type is changed and feature flag is enabled', async () => {
+    const onChange = vi.fn();
+    renderEditor(
+      {
+        onChange,
+        serviceJourney: createServiceJourney({
+          name: 'Route with Vehicle Type',
+          vehicleTypeRef: 'bus',
+          passingTimes: [{}, {}],
+        }),
+      },
+      {
+        config: { enableServiceJourneyVehicleTypeRef: true },
+      },
+    );
+
+    const vehicleTypeInput = screen.getByLabelText('Vehicle type');
+    await userEvent.type(vehicleTypeInput, '1');
+
+    expect(onChange).toHaveBeenCalled();
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+    expect(lastCall.vehicleTypeRef).toBe('bus1');
   });
 
   it('renders operator dropdown', () => {

--- a/src/components/ServiceJourneyEditor/index.tsx
+++ b/src/components/ServiceJourneyEditor/index.tsx
@@ -43,7 +43,7 @@ const ServiceJourneyEditor = (props: Props) => {
     copyServiceJourney,
     flexibleLineType,
   } = props;
-  const { name, description, privateCode, publicCode, passingTimes } =
+  const { name, description, privateCode, publicCode, passingTimes, vehicleTypeRef } =
     serviceJourney;
 
   const [operatorSelection, setOperatorSelection] = useState(
@@ -164,6 +164,20 @@ const ServiceJourneyEditor = (props: Props) => {
                 />
               )}
             />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6 }}>
+            <Tooltip title={formatMessage({ id: 'generalVehicleTypeTooltip' })}>
+              <TextField
+                fullWidth
+                label={formatMessage({ id: 'generalVehicleType' })}
+                value={vehicleTypeRef || ''}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  onFieldChange('vehicleTypeRef', e.target.value || null);
+                }}
+                variant="outlined"
+              />
+            </Tooltip>
+
           </Grid>
         </Grid>
 

--- a/src/components/ServiceJourneyEditor/index.tsx
+++ b/src/components/ServiceJourneyEditor/index.tsx
@@ -22,6 +22,7 @@ import CopyDialog from './CopyDialog';
 import Stack from '@mui/material/Stack';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
+import { useConfig } from '../../config/ConfigContext';
 
 type Props = {
   serviceJourney: ServiceJourney;
@@ -53,6 +54,8 @@ const ServiceJourneyEditor = (props: Props) => {
   const [showCopyDialog, setShowCopyDialog] = useState<boolean>(false);
   const organisations = useAppSelector((state) => state.organisations);
   const { formatMessage } = useIntl();
+  const config = useConfig();
+  const isVehicleTypeEnabled = config.enableServiceJourneyVehicleTypeRef ?? false;
 
   const handleOperatorSelectionChange = (
     newOperatorSelection: string | undefined,
@@ -165,20 +168,21 @@ const ServiceJourneyEditor = (props: Props) => {
               )}
             />
           </Grid>
-          <Grid size={{ xs: 12, sm: 6 }}>
-            <Tooltip title={formatMessage({ id: 'generalVehicleTypeTooltip' })}>
-              <TextField
-                fullWidth
-                label={formatMessage({ id: 'generalVehicleType' })}
-                value={vehicleTypeRef || ''}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  onFieldChange('vehicleTypeRef', e.target.value || null);
-                }}
-                variant="outlined"
-              />
-            </Tooltip>
-
-          </Grid>
+          {isVehicleTypeEnabled && (
+            <Grid size={{ xs: 12, sm: 6 }}>
+              <Tooltip title={formatMessage({ id: 'generalVehicleTypeTooltip' })}>
+                <TextField
+                  fullWidth
+                  label={formatMessage({ id: 'generalVehicleType' })}
+                  value={vehicleTypeRef || ''}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    onFieldChange('vehicleTypeRef', e.target.value || null);
+                  }}
+                  variant="outlined"
+                />
+              </Tooltip>
+            </Grid>
+          )}
         </Grid>
 
         <Notices

--- a/src/components/ServiceJourneyEditor/index.tsx
+++ b/src/components/ServiceJourneyEditor/index.tsx
@@ -44,8 +44,14 @@ const ServiceJourneyEditor = (props: Props) => {
     copyServiceJourney,
     flexibleLineType,
   } = props;
-  const { name, description, privateCode, publicCode, passingTimes, vehicleTypeRef } =
-    serviceJourney;
+  const {
+    name,
+    description,
+    privateCode,
+    publicCode,
+    passingTimes,
+    vehicleTypeRef,
+  } = serviceJourney;
 
   const [operatorSelection, setOperatorSelection] = useState(
     serviceJourney.operatorRef,
@@ -55,7 +61,8 @@ const ServiceJourneyEditor = (props: Props) => {
   const organisations = useAppSelector((state) => state.organisations);
   const { formatMessage } = useIntl();
   const config = useConfig();
-  const isVehicleTypeEnabled = config.enableServiceJourneyVehicleTypeRef ?? false;
+  const isVehicleTypeEnabled =
+    config.enableServiceJourneyVehicleTypeRef ?? false;
 
   const handleOperatorSelectionChange = (
     newOperatorSelection: string | undefined,
@@ -170,7 +177,9 @@ const ServiceJourneyEditor = (props: Props) => {
           </Grid>
           {isVehicleTypeEnabled && (
             <Grid size={{ xs: 12, sm: 6 }}>
-              <Tooltip title={formatMessage({ id: 'generalVehicleTypeTooltip' })}>
+              <Tooltip
+                title={formatMessage({ id: 'generalVehicleTypeTooltip' })}
+              >
                 <TextField
                   fullWidth
                   label={formatMessage({ id: 'generalVehicleType' })}

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -142,6 +142,12 @@ export interface Config {
    * Enable line migration feature for moving lines between providers
    */
   enableLineMigration?: boolean;
+
+  /**
+   * Enable vehicle type field in service journey editor.
+   * Defaults to false when omitted.
+   */
+  enableServiceJourneyVehicleTypeRef?: boolean;
 }
 
 export interface MapConfig {

--- a/src/i18n/translations/bg.ts
+++ b/src/i18n/translations/bg.ts
@@ -235,6 +235,8 @@ export const messages = {
   generalDescriptionFormGroupTitle: 'Описание',
   generalDescriptionLabel: 'Описание',
   generalDescription: 'Описание',
+  generalVehicleTypeTooltip: 'Тип на превозното средство, препратка към тип превозно средство в регистъра на превозните средства',
+  generalVehicleType: 'Тип на превозното средство',
   editorNetworkDescriptionLabelText: 'Описание',
   brandingsDescriptionTableHeaderLabel: 'Описание',
   editorBrandingDescriptionLabelText: 'Описание',

--- a/src/i18n/translations/bg.ts
+++ b/src/i18n/translations/bg.ts
@@ -235,7 +235,8 @@ export const messages = {
   generalDescriptionFormGroupTitle: 'Описание',
   generalDescriptionLabel: 'Описание',
   generalDescription: 'Описание',
-  generalVehicleTypeTooltip: 'Тип на превозното средство, препратка към тип превозно средство в регистъра на превозните средства',
+  generalVehicleTypeTooltip:
+    'Тип на превозното средство, препратка към тип превозно средство в регистъра на превозните средства',
   generalVehicleType: 'Тип на превозното средство',
   editorNetworkDescriptionLabelText: 'Описание',
   brandingsDescriptionTableHeaderLabel: 'Описание',

--- a/src/i18n/translations/en.ts
+++ b/src/i18n/translations/en.ts
@@ -232,7 +232,8 @@ export const messages: MessagesKey = {
   generalNameFormGroupTitle: 'Name *',
   generalNetworkFormGroupTitle: 'Network *',
   generalOperatorFormGroupTitle: 'Operator *',
-  generalVehicleTypeTooltip: 'Vehicle type, reference to a vehicle type in the vehicle registry',
+  generalVehicleTypeTooltip:
+    'Vehicle type, reference to a vehicle type in the vehicle registry',
   generalVehicleType: 'Vehicle type',
   transportModeTitle: 'Transport mode *',
   transportSubModeTitle: 'Transport submode *',

--- a/src/i18n/translations/en.ts
+++ b/src/i18n/translations/en.ts
@@ -232,6 +232,8 @@ export const messages: MessagesKey = {
   generalNameFormGroupTitle: 'Name *',
   generalNetworkFormGroupTitle: 'Network *',
   generalOperatorFormGroupTitle: 'Operator *',
+  generalVehicleTypeTooltip: 'Vehicle type, reference to a vehicle type in the vehicle registry',
+  generalVehicleType: 'Vehicle type',
   transportModeTitle: 'Transport mode *',
   transportSubModeTitle: 'Transport submode *',
   generalPrivateCodeFormGroupTitle: 'Private code',

--- a/src/i18n/translations/fi.ts
+++ b/src/i18n/translations/fi.ts
@@ -239,6 +239,8 @@ export const messages: MessagesKey = {
   generalPublicCodeInputLabelTooltip:
     'Julkinen tunnus on se, mikä tunnistaa linjan ulkoisesti matkustajille',
   generalTypeFormGroupTitle: 'Joustavan linjan tyyppi *',
+  generalVehicleTypeTooltip: 'Ajoneuvotyyppi, viittaus ajoneuvotyyppiin ajoneuvorekisterissä',
+  generalVehicleType: 'Ajoneuvotyyppi',
   typeFormGroupTitleTooltip: 'Lue lisää linjatyypeistä',
   editorGeneralTabLabel: 'Yleinen',
   generalDrawer: 'Alla on lyhyt kuvaus kustakin linjatyypistä.',

--- a/src/i18n/translations/fi.ts
+++ b/src/i18n/translations/fi.ts
@@ -239,7 +239,8 @@ export const messages: MessagesKey = {
   generalPublicCodeInputLabelTooltip:
     'Julkinen tunnus on se, mikä tunnistaa linjan ulkoisesti matkustajille',
   generalTypeFormGroupTitle: 'Joustavan linjan tyyppi *',
-  generalVehicleTypeTooltip: 'Ajoneuvotyyppi, viittaus ajoneuvotyyppiin ajoneuvorekisterissä',
+  generalVehicleTypeTooltip:
+    'Ajoneuvotyyppi, viittaus ajoneuvotyyppiin ajoneuvorekisterissä',
   generalVehicleType: 'Ajoneuvotyyppi',
   typeFormGroupTitleTooltip: 'Lue lisää linjatyypeistä',
   editorGeneralTabLabel: 'Yleinen',

--- a/src/i18n/translations/nb.ts
+++ b/src/i18n/translations/nb.ts
@@ -229,7 +229,8 @@ export const messages = {
   generalNameFormGroupTitle: 'Navn *',
   generalNetworkFormGroupTitle: 'Nettverk *',
   generalOperatorFormGroupTitle: 'Operatør *',
-  generalVehicleTypeTooltip: 'Kjøretøytype, referanse til en kjøretøytype i materiellregisteret',
+  generalVehicleTypeTooltip:
+    'Kjøretøytype, referanse til en kjøretøytype i materiellregisteret',
   generalVehicleType: 'Kjøretøytype',
   transportModeTitle: 'Transportgruppe *',
   transportSubModeTitle: 'Transportundergruppe *',

--- a/src/i18n/translations/nb.ts
+++ b/src/i18n/translations/nb.ts
@@ -229,6 +229,8 @@ export const messages = {
   generalNameFormGroupTitle: 'Navn *',
   generalNetworkFormGroupTitle: 'Nettverk *',
   generalOperatorFormGroupTitle: 'Operatør *',
+  generalVehicleTypeTooltip: 'Kjøretøytype, referanse til en kjøretøytype i materiellregisteret',
+  generalVehicleType: 'Kjøretøytype',
   transportModeTitle: 'Transportgruppe *',
   transportSubModeTitle: 'Transportundergruppe *',
   generalPrivateCodeFormGroupTitle: 'Privat kode',

--- a/src/i18n/translations/sv.ts
+++ b/src/i18n/translations/sv.ts
@@ -232,6 +232,8 @@ export const messages: MessagesKey = {
   generalOperatorFormGroupTitle: 'Operatör *',
   transportModeTitle: 'Transportgrupp *',
   transportSubModeTitle: 'Transportundergrupp *',
+  generalVehicleTypeTooltip: 'Fordonstyp, referens till en fordonstyp i fordonsregistret',
+  generalVehicleType: 'Fordonstyp',
   generalPrivateCodeFormGroupTitle: 'Privat kod',
   generalPrivateCodeInputLabelTooltip:
     'Privat kod är det som kännetecknar linjen internt hos en operatör',

--- a/src/i18n/translations/sv.ts
+++ b/src/i18n/translations/sv.ts
@@ -232,7 +232,8 @@ export const messages: MessagesKey = {
   generalOperatorFormGroupTitle: 'Operatör *',
   transportModeTitle: 'Transportgrupp *',
   transportSubModeTitle: 'Transportundergrupp *',
-  generalVehicleTypeTooltip: 'Fordonstyp, referens till en fordonstyp i fordonsregistret',
+  generalVehicleTypeTooltip:
+    'Fordonstyp, referens till en fordonstyp i fordonsregistret',
   generalVehicleType: 'Fordonstyp',
   generalPrivateCodeFormGroupTitle: 'Privat kod',
   generalPrivateCodeInputLabelTooltip:

--- a/src/model/ServiceJourney.ts
+++ b/src/model/ServiceJourney.ts
@@ -10,6 +10,7 @@ type ServiceJourney = VersionedType & {
   privateCode?: string | null;
   publicCode?: string | null;
   operatorRef?: string | null;
+  vehicleTypeRef?: string | null;
   bookingArrangement?: BookingArrangement | null;
   passingTimes: PassingTime[];
   dayTypes?: DayType[];
@@ -28,6 +29,7 @@ export const serviceJourneyToPayload = (sj: ServiceJourney) => {
       passingTimeToPayload(pt, i, sj.passingTimes.length),
     ),
     dayTypes: undefined,
+    vehicleTypeRef: sj.vehicleTypeRef || null,
     dayTypesRefs: sj.dayTypes?.map((dt) => dt.id!),
     notices: sj.notices?.filter(
       (notice) => notice && notice.text && notice.text !== '',


### PR DESCRIPTION
### Summary

Add an option to register serviceJourney.vehicleTypeRef. This is a reference to a vehicle type in the vehicle registry.
This feature is only enabled if config.enableServiceJourneyVehicleTypeRef = true